### PR TITLE
fix(db-migrate): add --rebless + pin *.sql to LF to stop checksum drift

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,11 @@
 # full-range scan rejects them. Pin to LF.
 *.html                text eol=lf
 *.js                  text eol=lf
+# Migrations: db-migrate.py checksums raw file bytes, so a CRLF-vs-LF checkout
+# difference (autocrlf on Windows runners) makes an already-applied migration
+# look "edited" and aborts the deploy. Pin LF so the bytes are identical on
+# every machine. See scripts/db-migrate.py --rebless for fixing existing drift.
+*.sql                 text eol=lf
 scripts/git-hooks/*   text eol=lf
 .git/hooks/*          text eol=lf
 # Docs and message catalogs: the mixed-line-ending pre-commit hook enforces LF,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,6 +146,24 @@ jobs:
             throw "Aborting deploy: neither $prodEnvFile nor $legacyProdEnvFile exists. The app will fail to load secrets without one of them."
           }
 
+      # db-migrate.py checksums raw file bytes; the persistent runner can carry
+      # CRLF .sql from before *.sql got `text eol=lf`, which makes an
+      # already-applied migration look "edited" and aborts the migrate step.
+      # Re-normalise to LF first (same reason as the .py step in the test job).
+      - name: Normalize SQL line endings to LF
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+          Get-ChildItem -Path sql -Recurse -Include *.sql | ForEach-Object {
+            $text = [System.IO.File]::ReadAllText($_.FullName, $utf8NoBom)
+            $normalized = $text -replace "`r`n", "`n"
+            if ($normalized -ne $text) {
+              [System.IO.File]::WriteAllText($_.FullName, $normalized, $utf8NoBom)
+              Write-Host "  fixed: $($_.FullName)"
+            }
+          }
+
       - name: Apply DB migrations to PROD
         shell: powershell
         run: |

--- a/scripts/db-migrate.py
+++ b/scripts/db-migrate.py
@@ -27,6 +27,11 @@ Migrations are immutable once applied: the runner refuses to re-run a file
 whose checksum no longer matches what was recorded at apply time. To make
 further changes, write a new migration.
 
+If a checksum drifts without a real content edit -- e.g. line-ending
+renormalization (the checksum is over raw bytes, so CRLF vs LF differs) --
+re-bless the recorded checksums to the current file bytes with ``--rebless``
+(no SQL is run; pair with ``--dry-run`` to preview first).
+
 Escape hatch (offline): ``SQL_SYNC_SKIP=1`` makes ``--check`` exit 0 without
 contacting the DB. Same env var also disables the pre-commit check.
 """
@@ -186,6 +191,20 @@ def record_applied(conn, filename: str, checksum: bytes) -> None:
         cur.close()
 
 
+def rebless_checksum(conn, filename: str, checksum: bytes) -> None:
+    """Overwrite the recorded checksum of an already-applied migration."""
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "UPDATE dbo.SchemaMigrations SET Checksum = ? WHERE FileName = ?",
+            checksum,
+            filename,
+        )
+        conn.commit()
+    finally:
+        cur.close()
+
+
 def plan_for_db(conn, db_folder: str) -> tuple[list[Path], list[Path]]:
     """Return (to_apply, mutated).
     - to_apply: unapplied files, in name order.
@@ -208,6 +227,30 @@ def run_for_db(args, cfg, db_folder: str, db_name: str, sqlcmd_exe: str) -> tupl
     conn = connect(cfg.DB_SERVER_PRD, db_name, cfg.DB_UID, cfg.DB_PWD)
     try:
         to_apply, mutated = plan_for_db(conn, db_folder)
+
+        if args.rebless:
+            if not mutated:
+                print("  no checksum drift -- nothing to re-bless")
+                return (0, 0)
+            print(f"  {len(mutated)} migration(s) with drifted checksums:")
+            for m in mutated:
+                print(f"    ~ {m.name}")
+            if args.dry_run:
+                print("  (--dry-run, not re-blessed)")
+                return (0, len(mutated))
+            if args.env == "PROD" and not args.yes:
+                ans = (
+                    input(f"  re-bless {len(mutated)} checksum(s) on PROD/{db_name}? [y/N] ")
+                    .strip()
+                    .lower()
+                )
+                if ans != "y":
+                    print("  skipped")
+                    return (0, len(mutated))
+            for m in mutated:
+                rebless_checksum(conn, m.name, file_checksum(m))
+                print(f"  ~> {m.name} (checksum updated)")
+            return (0, 0)
 
         if mutated:
             sys.stderr.write(f"  ERROR: {len(mutated)} migration(s) edited after being applied:\n")
@@ -288,6 +331,13 @@ def main() -> int:
         action="store_true",
         help="Record files as applied without running them (when already run in SSMS)",
     )
+    p.add_argument(
+        "--rebless",
+        action="store_true",
+        help="Update recorded checksums of already-applied migrations whose file "
+        "bytes drifted (e.g. line-ending renormalization). Runs no SQL; "
+        "use with --dry-run to preview.",
+    )
     p.add_argument("--yes", "-y", action="store_true", help="Skip the PROD confirmation prompt")
     args = p.parse_args()
 
@@ -309,7 +359,7 @@ def main() -> int:
 
     # sqlcmd only needed when we'll actually execute SQL.
     sqlcmd_exe = ""
-    if not (args.check or args.dry_run or args.mark_applied):
+    if not (args.check or args.dry_run or args.mark_applied or args.rebless):
         sqlcmd_exe = find_sqlcmd()
 
     total_applied = 0


### PR DESCRIPTION
Fixes the failed **Apply DB migrations to PROD** step on the post-#102 deploy.

**Root cause.** `db-migrate.py` aborted with *"16 migration(s) edited after being applied"* (`0004–0017, 0019, 0020`). None were actually edited — each has a single commit. The checksum is over **raw file bytes**, and `.gitattributes` `* text=auto` checks `.sql` out as **CRLF** on the Windows runner, while PROD's `SchemaMigrations` recorded **LF** checksums. So every already-applied migration looks mutated and the immutability gate fires before the genuinely-pending `0018` + `0021–0033` can apply. Same class as the prior INT CRLF drift.

**Changes**
- `.gitattributes`: pin `*.sql text eol=lf` — checksum bytes now identical everywhere.
- `deploy.yml`: normalize `sql/` to LF on the persistent runner before the migrate step (mirrors the existing `.py` step; `actions/checkout` doesn't re-normalize cached files).
- `db-migrate.py`: add `--rebless` — updates recorded checksums of already-applied migrations to the current file bytes. Runs no SQL; supports `--dry-run`; PROD confirm. (`--mark-applied` couldn't help — the immutability check aborts first.)

Verified: ruff, `py_compile`, YAML valid, `--rebless` in `--help`, renormalize causes no `.sql` blob churn (blobs already LF), and a mock test confirms drift detection + the `UPDATE … SET Checksum` path.

**Operator runbook (one-time, after merge)**
1. The deploy's new normalize step makes the runner's `.sql` LF.
2. Preview: `python scripts/db-migrate.py --env PROD --rebless --dry-run`
3. Apply:   `python scripts/db-migrate.py --env PROD --rebless`  (repeat `--env INT` to clear the latent INT drift)
4. Re-run the deploy — `db-migrate` now sees matching checksums.

If step 2 reports *"nothing to re-bless"*, the LF normalization already aligned PROD and you can skip straight to re-running the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEYuZQYx4mug4yEodrC8Jh
