### PR TITLE
fix(admin): pdbsUser access-profile assignment + permission API repairs (2.5.64)

### DIFF
--- a/.claude/helpers/notify-toast.ps1
+++ b/.claude/helpers/notify-toast.ps1
@@ -2,6 +2,12 @@
 #
 # Usage:
 #   powershell.exe -ExecutionPolicy Bypass -File <this-file> "<title>" "<body>"
+#
+# Toasts are shown under a dedicated "Claude Code" AppUserModelID (registered in
+# HKCU on first run). A fresh AppID starts with banners enabled, so notifications
+# pop as banners even when the generic "Windows PowerShell" identity has had its
+# banner turned off. If a banner still does not appear, check Windows Settings >
+# Notifications: Do Not Disturb / Focus off, and "Claude Code" banners on.
 
 param(
     [string]$Title = "Claude Code",
@@ -10,6 +16,7 @@ param(
 
 $ErrorActionPreference = 'SilentlyContinue'
 $logFile = "$PSScriptRoot\notify-toast.log"
+$AppId   = 'Claude.Code'
 
 function Log($msg) {
     try { "$([DateTime]::Now.ToString('HH:mm:ss.fff')) $msg" | Add-Content -Path $logFile } catch {}
@@ -17,37 +24,24 @@ function Log($msg) {
 
 Log "----- invoked -----"
 Log "PSVersion : $($PSVersionTable.PSVersion)"
-Log "Args      : $($args -join ' | ')"
 Log "Title     : $Title"
 Log "Body      : $Body"
-Log "PSScript  : $PSScriptRoot"
-Log "PWD       : $(Get-Location)"
-Log "User      : $env:USERNAME"
-Log "Session   : $env:SESSIONNAME"
 
 # --- audible cue ---
-try {
-    [System.Media.SystemSounds]::Exclamation.Play()
-    Log "Sound     : played"
-} catch {
-    Log "Sound err : $_"
-}
+try { [System.Media.SystemSounds]::Exclamation.Play(); Log "Sound     : played" }
+catch { Log "Sound err : $_" }
 
-# --- BurntToast ---
+# --- register a dedicated AppUserModelID once (cheap HKCU key, no shortcut needed) ---
 try {
-    if (Get-Module -ListAvailable -Name BurntToast) {
-        Import-Module BurntToast -ErrorAction Stop
-        New-BurntToastNotification -Text $Title, $Body -ErrorAction Stop
-        Log "BurntToast: shown"
-        exit 0
-    } else {
-        Log "BurntToast: not installed"
+    $key = "HKCU:\Software\Classes\AppUserModelId\$AppId"
+    if (-not (Test-Path $key)) {
+        New-Item -Path $key -Force | Out-Null
+        New-ItemProperty -Path $key -Name DisplayName -Value 'Claude Code' -PropertyType String -Force | Out-Null
+        Log "AppId     : registered $AppId"
     }
-} catch {
-    Log "BurntToast err: $_"
-}
+} catch { Log "AppId err : $_" }
 
-# --- WinRT toast under PowerShell AppUserModelID ---
+# --- WinRT toast under the Claude Code identity ---
 try {
     [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
     $template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent(
@@ -57,15 +51,15 @@ try {
     $textNodes.Item(0).AppendChild($template.CreateTextNode($Title)) | Out-Null
     $textNodes.Item(1).AppendChild($template.CreateTextNode($Body))  | Out-Null
     $toast = [Windows.UI.Notifications.ToastNotification]::new($template)
-    [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier(
-        '{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\WindowsPowerShell\v1.0\powershell.exe'
-    ).Show($toast)
-    Log "WinRT     : Show() called under registered PowerShell AppUserModelID"
+    [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($AppId).Show($toast)
+    Log "WinRT     : shown under $AppId"
+    Log "----- done -----`n"
+    exit 0
 } catch {
     Log "WinRT err : $_"
 }
 
-# --- NotifyIcon balloon fallback (always works) ---
+# --- NotifyIcon balloon fallback (only reached if the WinRT toast threw) ---
 try {
     Add-Type -AssemblyName System.Windows.Forms
     Add-Type -AssemblyName System.Drawing
@@ -75,12 +69,10 @@ try {
     $balloon.BalloonTipText  = $Body
     $balloon.Visible = $true
     $balloon.ShowBalloonTip(5000)
-    Start-Sleep -Milliseconds 500
+    Start-Sleep -Milliseconds 800
     $balloon.Dispose()
-    Log "Balloon   : ShowBalloonTip() called and disposed"
-} catch {
-    Log "Balloon err: $_"
-}
+    Log "Balloon   : shown (fallback)"
+} catch { Log "Balloon err: $_" }
 
 Log "----- done -----`n"
 exit 0

--- a/.claudeignore
+++ b/.claudeignore
@@ -47,6 +47,7 @@ ruvector.db
 .swarm/
 .claude-flow/
 .superpowers/
+!.superpowers/sdd/
 .playwright-mcp/
 .claude/memory.db
 .claude/cache/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,6 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           D:\sydoc\tools\py\python.exe -m pytest tests `
-            --reruns 2 --only-rerun flaky_e2e `
             -p no:cacheprovider `
             -o junit_logging=all
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,11 @@ repos:
 
       - id: pytest-pre-push
         name: Test suite (pre-push gate)
-        entry: python -m pytest tests --reruns 2 --only-rerun flaky_e2e
+        # E2E retries are armed by tests/e2e/conftest.py (pytest.mark.flaky),
+        # not CLI flags: --only-rerun is an error-text regex, and
+        # "--only-rerun flaky_e2e" never matched anything, so no test was
+        # ever actually retried.
+        entry: python -m pytest tests
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,27 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-Work toward 2.5.63 (version bumped from 2.5.60; now single-sourced in `nx_lib/version.py`).
+Work toward 2.5.64.
+
+### Added
+
+- `scripts/new-process.py` — interactive dev-side helper that assembles a new
+  `dbo.Statconfig` row (process name, stat table, export/import/workitem columns,
+  client code) when onboarding a new Octo process. Prints the INSERT for review;
+  the actual DB write is still commented out (WIP). Dev-only: `scripts/` is
+  excluded from the prod deploy mirror.
+
+### Fixed
+
+- Dashboard statistics: the two PDBS deletion-marker activity instances
+  (`Deletion Marker PDBS Parent Batch Deletion`, `Deletion Marker PDBS Deckblatt`
+  on `sydoc.05_PDBS`) no longer pollute the stats — they are seeded into
+  `dbo.ActivityInstancesToIgnore` by migration `0032` (idempotent `NOT EXISTS`
+  inserts, so environments where the rows were already added by hand are safe).
+
+## [2.5.63] - 2026-06-24
+
+Version bumped from 2.5.60; now single-sourced in `nx_lib/version.py`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ Work toward 2.5.64.
   on `sydoc.05_PDBS`) no longer pollute the stats — they are seeded into
   `dbo.ActivityInstancesToIgnore` by migration `0032` (idempotent `NOT EXISTS`
   inserts, so environments where the rows were already added by hand are safe).
+- Admin: camelCase-named access profiles (e.g. `pdbsUser`) were unassignable
+  in the admin UI even for holders of the grant permission, because the
+  hand-inserted permission code (`admin.assign.user.accessprofile.pdbsUser`)
+  didn't match the lowercased code the app checks — the profile was silently
+  filtered out of every assignable-profiles dropdown. `has_permission()`
+  (`nx_lib/security.py`) is now case-insensitive, and migration `0034`
+  normalizes the stray row to lowercase.
+- Admin: the permission add/edit APIs and the user-all-permissions API
+  returned 500 on every environment — they referenced `dbo.Permission.SortingCode`,
+  a column that never existed until migration `0034` added it.
+- **Security:** `admin_add_user` now enforces the
+  `admin.assign.user.accessprofile.<profile>` permission the same way user
+  editing already did. Previously any `admin.create.user` holder could create
+  a user with any access profile (including `enterpriseAdmin`) via a direct
+  API request, bypassing the add-user dropdown's filtered list.
 
 ## [2.5.63] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ Work toward 2.5.64.
   editing already did. Previously any `admin.create.user` holder could create
   a user with any access profile (including `enterpriseAdmin`) via a direct
   API request, bypassing the add-user dropdown's filtered list.
+- Testing: the flaky-E2E retry net never actually retried anything — the
+  pre-push and CI gates passed `--only-rerun flaky_e2e`, but that flag is an
+  error-text regex (no traceback contains "flaky_e2e"), so a single browser
+  race failed the whole gate. Retries are now armed in `tests/e2e/conftest.py`
+  for every E2E test by directory (40+ tests had also drifted out of the net
+  by missing the marker); the broken CLI flags are removed from
+  `.pre-commit-config.yaml`, `deploy.yml`, `README.md`, and
+  `scripts/git-hooks/pre-push`. Unit/integration tests still get zero retries.
 
 ## [2.5.63] - 2026-06-24
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ For setup details — what bootstrap does and how to do each step by hand if it 
 ## Running tests
 
 ```powershell
-python -m pytest tests -v --reruns 2 --only-rerun flaky_e2e
+python -m pytest tests -v
 ```
+
+E2E browser tests are automatically retried up to twice on failure (armed in `tests/e2e/conftest.py`); unit and integration tests fail fast with no retries.
 
 The pre-push hook runs the same command on every `git push`. Bypass with `--no-verify` (CI still gates deploy).
 

--- a/docs/superpowers/handoffs/2026-07-13-pdbsuser-assign-permission-fix-execution-complete.md
+++ b/docs/superpowers/handoffs/2026-07-13-pdbsuser-assign-permission-fix-execution-complete.md
@@ -1,0 +1,157 @@
+# Handoff — pdbsUser Access-Profile Assignment Fix (EXECUTED — ready to merge)
+
+**Date:** 2026-07-13 · **Branch:** `feature/2.5.64` · **9 commits ahead of origin** · **commit-only (remote)** · no plan worktree
+**Prior handoff:** none this cycle — first work on `feature/2.5.64` (opened 2026-07-13, prior handoff was the June 24 `prepared-docs-preview-fixes` cycle on `feature/2.5.63`, already merged to main)
+**Plan executed:** `docs/superpowers/plans/2026-07-13-pdbsuser-assign-permission-fix.md`
+**SDD ledger:** `.superpowers/sdd/progress.md` (full per-task review record; gitignored scratch)
+
+## TL;DR
+
+- **All 7 plan tasks executed, reviewed, and committed.** 8 commits on `feature/2.5.64`
+  (`673a552..f84a14a`, where `673a552` is the plan-doc commit itself). Nothing left to implement.
+- Fixed three confirmed defects: (1) `pdbsUser` access profile was silently unassignable in the admin
+  UI due to a case-mismatch between a hand-inserted permission code and the lowercased code the app
+  checks; (2) admin permission add/edit + user-all-permissions APIs 500'd on every environment
+  (missing `Permission.SortingCode` column); (3) a **privilege-escalation gap** — `admin_add_user`
+  never checked the assign-permission, so any `admin.create.user` holder could create a user with
+  ANY profile (including `enterpriseAdmin`) via a direct POST.
+- **Final whole-branch review (opus): READY TO MERGE.** No Critical, no Important, across the full
+  `main`-merge-base range (12 commits, incl. 4 pre-plan commits already on the branch). 3 Minors, all
+  cosmetic or explicitly out-of-plan-scope.
+- **Live INT browser verification: all 4 checklist items PASS** on a freshly-restarted server (see
+  Gotchas for the tooling substitution).
+- **Owner still owes:** `git push` + PR→main (remote/commit-only — never done here), plus the
+  optional immediate PROD migration apply (see Owner actions below).
+
+## This session's commits (oldest → newest)
+
+```
+673a552  docs(plan): pdbsUser assign-permission fix plan                        (pre-existing, plan doc)
+903668e  fix(db): add Permission.SortingCode; normalize pdbsUser code (0034)    (Task 1)
+e313b4c  fix(security): case-insensitive permission code matching              (Task 2)
+7b59a3a  refactor(hooks): use has_permission for maintenance bypass            (Task 3)
+b4e99ab  test(admin): tighten permission API statuses + CRUD round-trip        (Task 4)
+1554a2b  test(admin): use mixed-case code in permission round-trip test        (Task 4 fix)
+6bb97e3  fix(admin): enforce assign-profile permission on user creation        (Task 5, SECURITY)
+5ae3589  test(admin): fix allow-path cleanup to actually delete the test user  (Task 5 fix)
+f84a14a  docs(changelog): pdbsUser assign fix + permission API repairs         (Task 6)
+```
+(Task 7 was live-verification only, no commits. The handoff commit for THIS doc lands on top of `f84a14a`.)
+
+## What shipped (7 files touched by the plan, across 8 commits)
+
+| Task | Fix | Files | Commit(s) |
+|---|---|---|---|
+| **1** Migration 0034 | Added `SortingCode nvarchar(50) NULL` to `dbo.Permission`; normalized the one hand-inserted mixed-case row (`...pdbsUser` → `...pdbsuser`), collation-proof `WHERE LOWER(Code)=...`. Mirrored in test schema. | `sql/_migrations/NexoraDB/0034_permission_sortingcode_and_pdbsuser_case.sql`, `sql/NexoraDB/Tables/dbo.Permission.sql` (regenerated), `sql/test/schema.sql` | `903668e` |
+| **2** Case-insensitive matching | `has_permission()` now lowercases both sides — the fix that makes Task 1's data repair actually take effect everywhere. | `nx_lib/security.py`, `tests/unit/test_security.py` | `e313b4c` |
+| **3** Hooks reroute | Maintenance-lockout bypass check routed through `has_permission()` instead of raw list membership, so it benefits from Task 2 too. | `nx_lib/hooks.py`, `tests/unit/test_hooks.py` | `7b59a3a` |
+| **4** Test tightening + round-trip | 4 tolerant `in (200, 500)` assertions → strict; new CRUD round-trip test proving `Code`/`SortingCode` survive add→edit with case preserved (mixed-case value, after a review round caught an all-lowercase value that couldn't prove it). | `tests/integration/test_admin_routes.py` | `b4e99ab`, `1554a2b` |
+| **5** Add-user authz gap (SECURITY) | `admin_add_user` gated with the same `admin.assign.user.accessprofile.<profile>` check `admin_edit_user` already had; `%r`-parameterized logging (not f-string) to prevent log injection from request-controlled values. Deny-path test proves both 403 AND zero rows persisted. | `nx_lib/views/admin.py`, `tests/integration/test_admin_routes.py` | `6bb97e3`, `5ae3589` |
+| **6** Changelog | 3 `### Fixed` bullets under `[Unreleased]`, verified against actual shipped code, no overclaiming. No docs page existed to add a permission-code-convention note to — correctly skipped rather than inventing one. | `CHANGELOG.md` | `f84a14a` |
+| **7** Live verification | Browser-driven: `pdbsUser` confirmed present in both add-user and edit-user dropdowns; throwaway user create+delete end-to-end; throwaway permission add+delete (no 500s). All 4 PASS. No commits (verification only). | — | — |
+
+**No new top-level files/dirs** (no `deploy.yml` exclude changes needed). **No new i18n strings** (reused the existing `_("Permission Denied for this action.")`, no pybabel cycle needed).
+
+## How it was executed (subagent-driven development)
+
+Fresh implementer subagent per task → task review (spec + quality) → fix loop → next; then one opus
+whole-branch review. Models: sonnet implementers/reviewers throughout, opus for the Task 5 review
+(security-critical) and the final whole-branch review. Two review cycles found real, fixed issues:
+
+- **Task 4:** the round-trip test's `code` value was all-lowercase (`test.roundtrip.perm`), so its
+  "case preserved" assertion couldn't have caught a hypothetical lowercase-on-save regression — only
+  `SortingCode` was meaningfully tested. Fixed by switching to a mixed-case code value; independently
+  re-verified the route does no case normalization (`.strip()` only).
+- **Task 5:** the allow-path test's cleanup called the app's own `/admin/users/delete/<id>` route,
+  but that route's cascading delete hits `tags`/`workitem_metadata` tables NEXORA_TEST doesn't have,
+  so it 500s on the first statement and never actually deletes — every run was orphaning a
+  `task5-allow-*` row in the shared test DB. Fixed with a direct SQL delete + verified-gone assertion;
+  6 pre-existing leaked rows were found and purged during the fix.
+
+Full review trail (all per-task ✅/❌ verdicts, evidence, file:line citations) in
+`.superpowers/sdd/progress.md`.
+
+## Next steps (ordered)
+
+1. **Owner: `git push`** `feature/2.5.64` and **open the PR → main** (remote/commit-only — the agent
+   never pushes). Pre-push runs the full suite incl. Playwright e2e.
+2. **Owner: PROD fix timing.** Migration `0034` auto-applies on the next deploy to `main`. To fix PROD
+   immediately instead: `python scripts/db-migrate.py --env PROD` (idempotent; will also record
+   `0032`, which is safe — its rows already exist by hand per the prior release-open commit).
+3. **Owner: post-deploy PROD spot-check** — assign `pdbsUser` to one user via the UI.
+4. Optional cosmetic cleanup (non-blocking Minor from final review): `test_api_admin_permission_users_seeded`
+   (`tests/integration/test_admin_routes.py:468`) still asserts `in (200, 500)` — its route never
+   referenced `SortingCode` so it was correctly out of Task 4's scope, but NEXORA_TEST now supports it
+   reliably returning 200; tighten to `== 200` for symmetry with its sibling test if touching that file again.
+
+## Owner actions baked into the plan (not the agent's job)
+
+- **PROD migration timing / manual apply** — see Next steps #2 above.
+- **Post-deploy PROD spot-check** — see Next steps #3 above.
+- **Review + push `feature/2.5.64`** — full pre-push gate (Playwright e2e).
+
+## Follow-ups deliberately NOT done (per the plan — don't pick these up without a fresh spec)
+
+- Case-insensitive matching for the reporting raw-membership sites (`nx_lib/reporting/sources.py
+  accessible()`, `nx_lib/reporting/runner.py`) — reporting source grants are separate machinery.
+- `admin_edit_user` currently lets an assign-permission holder change the password of ANY existing
+  user, including ones whose CURRENT profile they couldn't assign — a separate, pre-existing gap,
+  noted but not fixed (needs its own spec discussion).
+- The stale header comment in `test_admin_routes.py` claiming `admin@test.local` has only 3
+  permissions (it actually has every seeded permission) — fix opportunistically if touching that file
+  again for another reason.
+
+## Gotchas & notes (READ)
+
+- **Live browser verification used a tooling substitution.** The `claude-in-chrome` extension was
+  unreachable this session — the OS default browser is Firefox, and the installed Chrome had no
+  extension in its profile. Per the plan's own fallback guidance, Task 7 drove a standalone Playwright
+  script (same Chromium/tooling the project's own `tests/e2e/` suite already depends on) against the
+  live INT server instead. Same rigor: real clicks, real network requests, screenshots at each step.
+  No application code was touched during verification.
+- **Screenshots** at `var/screenshots/pdbsuser-assign-*.png` (9 files, gitignored — not committed,
+  not attached to this handoff).
+- **`%r` logging is deliberate, not a style choice.** The new gate in `admin_add_user`
+  (`nx_lib/views/admin.py`) logs `profile=%r username=%r` with values as separate positional args,
+  NOT an f-string — `accessprofile`/`username` are request-controlled, and an f-string would let a
+  request inject newlines/control characters into `var/logs/system/app.log`. Do not "clean this up"
+  into an f-string.
+- **Two-target monkeypatch trap (bit a prior plan draft, avoided here).** `nx_lib/views/admin.py`
+  imports `has_permission` at module load, so inline gate calls in route bodies resolve
+  `nx_lib.views.admin.has_permission` — patching `nx_lib.security.has_permission` only reaches the
+  `@require_permission` decorator's closure. All Task 5 tests correctly patch the view-module binding.
+- **`*.filter.process.<client>.<Process>` codes are safe from Task 2's lowercasing** (verified at the
+  final review, not just asserted): they're consumed via prefix-split iteration over
+  `session['permissions']` (case-preserving reconstruction), never through `has_permission()` — so
+  Task 2 cannot corrupt IDs 176/177 or any future case-significant code of that shape.
+- **`SQL_SYNC_SKIP=1`** was used where needed for the migration commit (known INT `SchemaMigrations`
+  CRLF drift on Windows). Never `--no-verify`. All commits landed clean.
+- **Migration numbering note (pre-existing, not introduced this session):** `0032` (added by the
+  release-open commit just before this session) sorts before the already-existing `0033` — benign,
+  `db-migrate.py` tracks applied files individually, not sequentially; flagged by the final reviewer
+  as informational only.
+- **Pre-existing unrelated stray in a non-plan commit:** `scripts/new-process.py:52` (WIP helper, not
+  part of this plan) has a commented-out latent SQL f-string bug — dead code, harmless, noted by the
+  final reviewer for completeness only.
+
+## Untracked / left for owner
+
+Working tree is clean — nothing untracked or uncommitted at handoff time. No strays this session.
+
+## How to verify
+
+```powershell
+# From C:\dev\nexora (feature/2.5.64):
+git log --oneline 673a552..HEAD                 # the 8 plan-execution commits + this handoff
+git status --porcelain                          # should be empty
+
+# Feature test slices (all green at handoff):
+.venv\Scripts\python -m pytest tests/unit/test_security.py tests/unit/test_hooks.py -q
+.venv\Scripts\python -m pytest tests/integration/test_admin_routes.py -q   # hits live NEXORA_TEST
+```
+
+## Resuming in a fresh session
+
+This feature is **done and ready to merge** — the remaining items are owner-only (push + PR + PROD
+migration timing + spot-check). If resuming: `/reset-session` (the `var/handoff-pending` flag points
+here).

--- a/docs/superpowers/plans/2026-07-13-pdbsuser-assign-permission-fix.md
+++ b/docs/superpowers/plans/2026-07-13-pdbsuser-assign-permission-fix.md
@@ -1,0 +1,166 @@
+# pdbsUser Access-Profile Assignment Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Executor model: Sonnet. This plan was adversarially reviewed by three agents (anchor-verification, executor red-team, security) on 2026-07-13; their findings are folded in — trust the anchors.
+
+**Goal:** Make the `pdbsUser` access profile assignable in the admin UI (add-user AND edit-user flows) for holders of its assign permission, and fix the three confirmed defects around it: (1) a **case-mismatch** between the hand-inserted permission code `admin.assign.user.accessprofile.pdbsUser` and the lowercased code the app checks; (2) the admin **permission add/edit/all-permissions APIs 500 on every environment** because they reference a `Permission.SortingCode` column that was never migrated — which is why the permission row was hand-typed in SSMS in the first place; (3) an **authz gap**: `admin_add_user` never checks the assign permission (the add-user dropdown is the only gate; a direct POST can assign ANY profile, including `enterpriseAdmin`, with only `admin.create.user`). The gate fix closes the **add-user** escalation specifically; the user-override editor and profile editor are separately-gated trust boundaries and stay as they are.
+
+**Confirmed root cause (do not re-investigate):**
+- `nx_lib/security.py` `has_permission` is an exact, case-sensitive set-membership check: `return code in perms`.
+- `nx_lib/views/admin.py` builds assign codes lowercased at three sites (anchor snippet, appears 3×): `f"admin.assign.user.accessprofile.{str(accessprofile).lower()}"` / `f'admin.assign.user.accessprofile.{str(ap["profile"]).lower()}'` — in `admin_edit_user` (403 gate), `admin_user_detail` (assignable list), `admin_access_control` (assignable list).
+- Live INT `dbo.Permission` (verified 2026-07-13): all nine older assign rows are lowercase (`...issuser`, `...nexorauser`, …); **only** PermissionID 179 is mixed-case: `admin.assign.user.accessprofile.pdbsUser`. PROD has the same hand-inserted row. So the app checks `...pdbsuser`, the grant says `...pdbsUser`, and the profile is silently filtered out of every assignable-profiles dropdown; direct edit 403s.
+- Live INT `dbo.Permission` columns are ONLY `PermissionID, Code, Description` (verified via INFORMATION_SCHEMA). `api_admin_permission_add`, `api_admin_permission_edit`, and `api_admin_user_all_permissions` all reference `SortingCode` → those routes throw and return 500 today on INT and PROD. `sql/test/schema.sql` also lacks the column, and the integration tests tolerate it via `assert resp.status_code in (200, 500)` — which is why CI never caught it.
+- Live INT collation is `SQL_Latin1_General_CP1_CI_AS` (case-insensitive; verified via `DATABASEPROPERTYEX`) and `Permission.Code` carries a UNIQUE constraint — so two codes differing only by case cannot coexist, which makes case-insensitive matching in `has_permission` unambiguous. The per-object dump only proves the UNIQUE constraint, not the collation; the migration below is written collation-proof anyway.
+
+**Architecture of the fix (defense in depth, all layers small):**
+1. Migration `0034`: add `SortingCode nvarchar(50) NULL` to `dbo.Permission` + lowercase the stray `pdbsUser` code row. Data + schema repair for INT (auto-applied by the pre-commit hook) and PROD (auto-applied by the next deploy).
+2. `has_permission` becomes case-insensitive (lowercase both sides) — kills the trap for every `has_permission` / `require_permission` call site, including future hand-inserted rows.
+3. The maintenance-bypass check in `nx_lib/hooks.py` does raw `in session['permissions']` — route it through `has_permission` so it benefits too. (Two other raw-membership holdouts exist in `nx_lib/reporting/sources.py` `accessible()` and `nx_lib/reporting/runner.py`; they are **deliberately out of scope** — reporting source grants are their own machinery. Noted as follow-up.)
+4. `admin_add_user` gets the same assign-permission gate `admin_edit_user` already has.
+5. The over-tolerant integration tests are tightened and a strict add→edit→delete round-trip is added, so a broken permission API can never ride green again.
+
+**Explicitly NOT done (decided against, don't add back):** lowercasing permission codes at creation/edit time. Live INT holds **case-significant** codes — `dashboard.filter.process.sydoc.05_PDBS` (ID 176) and `workitems.filter.process.sydoc.05_PDBS` (ID 177) — whose last segments are extracted **verbatim** by `nx_lib/process_helpers.py` and compared case-sensitively against Postgres process names. Normalizing on save would corrupt any such code re-saved through the UI. Case-insensitive **matching** (layer 2) fixes the assign trap without touching stored case.
+
+**Tech stack:** Python 3.13 / Flask, pyodbc raw cursors in `nx_lib/views/admin.py`, pytest (`tests/unit`, `tests/integration` against NEXORA_TEST), SQL Server migrations under `sql/_migrations/NexoraDB/`.
+
+---
+
+## Context an engineer needs (read first)
+
+- **Branch:** `feature/2.5.64` (already exists, tracks origin). This plan file is already committed. Commit per task. **Do NOT push and do NOT open a PR** — the owner reviews and pushes (the pre-push hook runs the full suite incl. Playwright e2e, owner runs it).
+- **TDD is the house rule:** each task writes the failing test first, sees it fail, then implements. Use `superpowers:test-driven-development`.
+- **Anchor on snippets, never line numbers** — quote-match the exact code shown in each task; line numbers drift.
+- **Monkeypatching `has_permission` — two different targets (this bit the plan's first draft):** `nx_lib/views/admin.py` does `from ..security import ... has_permission ...` at module load, so **inline** calls inside route bodies resolve `nx_lib.views.admin.has_permission`. Patching `nx_lib.security.has_permission` reaches **only** the `@require_permission` decorator closures. The existing `admin_all_perms` fixture patches the security module — it does NOT reach inline gates. The repo's established pattern for inline gates patches the view module (see `tests/integration/test_workitems_routes.py`, `monkeypatch.setattr(wv, "has_permission", ...)`). Also note: the header comment in `test_admin_routes.py` claiming admin@test.local has only 3 permissions is stale — `sql/test/seed.sql` grants the TestAdmin profile **every seeded permission** (but NO `admin.assign.user.accessprofile.*` rows exist in the seed at all).
+- **Test cleanup goes through the app, not `db_conn`:** the `db_conn` fixture is transaction-scoped and **rolls back** at test end, while routes commit through the app's own connection — rows created via routes survive. There is no add-then-cleanup precedent in `test_admin_routes.py`. Clean up by calling the app's delete APIs in `try/finally` (`/api/admin/permissions/delete/<id>`, and the admin user-delete route — read its registration in `admin.py` for the exact path).
+- **Migration numbering:** next free number was `0034` on 2026-07-13 (`sql/_migrations/NexoraDB/` tops out at `0033_create_prepared_documents.sql`). **Re-list the directory at execution time** and bump if taken. Migrations MUST be idempotent — the pre-commit hook auto-applies them to INT and may re-run them.
+- **`*.sql` is pinned to LF** by `.gitattributes` — write the migration with the Write tool (LF), not shell heredocs.
+- **Pre-commit hook** runs `scripts/db-migrate.py --env INT` + `sql/sync-from-db.py --check` on every commit. The new column changes `dbo.Permission` DDL, so the sync step will regenerate `sql/NexoraDB/Tables/dbo.Permission.sql` — **`git add` the regenerated file into the same commit** when the hook reports drift. Never hand-edit files under `sql/NexoraDB/`. `SQL_SYNC_SKIP=1` is only for INT-unreachable flakes, never to silence a real failure.
+- **gitlint:** conventional-commit title, no "WIP" in title, body required.
+- **Test commands:** unit `.venv\Scripts\python -m pytest tests/unit/test_security.py -q`; integration `.venv\Scripts\python -m pytest tests/integration/test_admin_routes.py -q`. Integration tests hit the NEXORA_TEST DB on INTSQL01. **`scripts/test_db_reset.py` applies `sql/test/schema.sql` + `seed.sql`** — run it after Task 1 edits schema.sql so NEXORA_TEST actually has the new column.
+- **i18n:** reuse the existing translated string `_("Permission Denied for this action.")` for the new 403 — introduce **no new user-facing strings**, then no pybabel cycle is needed. If you do add a string, you must run the full `/nx-i18n` cycle or the gate fails.
+- **No template changes are required** (dropdowns are server-populated from `assignable_profiles`). For the live browser verification, restart the dev server first — templates and code are cached for the process lifetime.
+- **No new top-level files/dirs** → no `deploy.yml` exclude changes.
+
+---
+
+## Decisions locked in
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Keep the `.lower()` convention at the three assign-check sites; do NOT switch them to verbatim profile names | Nine existing lowercase rows depend on it; verbatim would need renaming all of them |
+| 2 | `has_permission` lowercases both sides | CI-unique `Permission.Code` (live INT collation `SQL_Latin1_General_CP1_CI_AS`) means case variants can't coexist → widening is unambiguous; protects against future SSMS hand-inserts |
+| 3 | Migration also lowercases the stray row (belt + braces with #2), with a collation-proof WHERE | DB stays convention-consistent; works even if a future environment were CS-collated |
+| 4 | `SortingCode` is `nvarchar(50) NULL` | UI placeholder is "e.g. A1"; NULLs sort first under `ORDER BY p.SortingCode, p.Code`, acceptable |
+| 5 | `admin_add_user` reuses the gate shape from `admin_edit_user` (403 + logger), but with parameterized logging | Consistency; the f-string variant would let request-controlled values inject newlines into `var/logs/system/app.log` |
+| 6 | NO lowercase-on-save in the permission CRUD routes | Would corrupt case-significant `*.filter.process.<client>.<Process>` codes matched verbatim against Postgres (see "Explicitly NOT done") |
+| 7 | Only the pdbsUser row is data-fixed; no blanket `LOWER(Code)` sweep | Same reason as #6 |
+
+---
+
+## Task 1 — Migration 0034: SortingCode column + pdbsUser code case
+
+- [ ] Create `sql/_migrations/NexoraDB/0034_permission_sortingcode_and_pdbsuser_case.sql` (re-verify the number is free):
+
+```sql
+-- 0034_permission_sortingcode_and_pdbsuser_case.sql
+-- 1) dbo.Permission.SortingCode: referenced by the admin permission APIs
+--    (api_admin_permission_add/edit, api_admin_user_all_permissions) since the
+--    April admin redesign, but the column was never migrated -> those routes 500.
+-- 2) Normalize the one hand-inserted mixed-case assign code to the lowercase
+--    convention the app checks (admin.py builds codes with .lower()).
+-- Idempotent: guarded / naturally re-runnable. LOWER() makes the match
+-- collation-proof (CI or CS).
+
+IF COL_LENGTH('dbo.Permission', 'SortingCode') IS NULL
+    ALTER TABLE dbo.Permission ADD SortingCode nvarchar(50) NULL;
+GO
+
+UPDATE dbo.Permission
+SET Code = 'admin.assign.user.accessprofile.pdbsuser'
+WHERE LOWER(Code) = 'admin.assign.user.accessprofile.pdbsuser';
+GO
+```
+
+- [ ] Add the column to the test schema: in `sql/test/schema.sql`, find the `CREATE TABLE` for `Permission` (anchor: the `Code` + `Description` column pair) and add `SortingCode nvarchar(50) NULL` after `Description`. Do NOT touch `sql/test/seed.sql` (its inserts name their columns).
+- [ ] Run `.venv\Scripts\python scripts/test_db_reset.py` so NEXORA_TEST picks up the column.
+- [ ] Commit (`fix(db): add Permission.SortingCode + normalize pdbsUser assign code (0034)`). The hook applies 0034 to INT and regenerates `sql/NexoraDB/Tables/dbo.Permission.sql` — add the regenerated dump to the same commit when the sync step flags it.
+
+**Verify:** query INT INFORMATION_SCHEMA → the column exists; `SELECT Code FROM Permission WHERE Code LIKE '%pdbs%'` returns the all-lowercase code.
+
+## Task 2 — has_permission becomes case-insensitive (unit-first)
+
+- [ ] In `tests/unit/test_security.py`, add failing tests following the file's existing session-mocking pattern: with `session['permissions'] = ['admin.assign.user.accessprofile.pdbsUser']`, `has_permission('admin.assign.user.accessprofile.pdbsuser')` is True; the reverse direction too; a genuinely-absent code stays False.
+- [ ] Implement in `nx_lib/security.py` — anchor:
+
+```python
+def has_permission(code: str) -> bool:
+    perms = set(session.get("permissions", []))
+    return code in perms
+```
+
+becomes lowercase-both-sides (e.g. `return code.lower() in {p.lower() for p in perms}`). Keep the signature and style.
+- [ ] Run the unit file AND grep `tests/` for any test asserting case-SENSITIVE permission behavior (none known, but confirm) — all green. Commit (`fix(security): case-insensitive permission code matching`), body citing the CI-unique-index safety argument.
+
+## Task 3 — Route the maintenance-bypass check through has_permission
+
+- [ ] In `nx_lib/hooks.py`, find the raw membership check (anchor: `"admin.maintenance.bypass" in (session.get("permissions") or [])`) and replace it with `has_permission("admin.maintenance.bypass")` (import it the way the module already imports from `nx_lib.security`, or add the import).
+- [ ] If a unit test covers the maintenance hook, extend it with a mixed-case session entry proving the bypass now matches case-insensitively; if none exists, add a minimal one only if the file's structure makes it cheap — otherwise the Task 2 unit tests already cover the function itself.
+- [ ] Commit (`refactor(hooks): use has_permission for maintenance bypass`). Body notes the remaining raw-membership holdouts (`nx_lib/reporting/sources.py` `accessible()`, `nx_lib/reporting/runner.py`) are deliberate follow-ups, not oversights.
+
+## Task 4 — Tighten the permission-API tests + strict round-trip
+
+- [ ] In `tests/integration/test_admin_routes.py` (all use `admin_all_perms` — fine here, these routes gate via decorators only):
+  - `test_api_admin_user_all_permissions` → `assert resp.status_code == 200`
+  - `test_api_admin_permission_add_missing_body` → `assert resp.status_code == 400`
+  - `test_api_admin_permission_edit_unknown` → `assert resp.status_code == 404` (route checks `cursor.rowcount == 0` → 404)
+  - `test_api_admin_permission_delete_unknown` → `assert resp.status_code == 404` (same pattern)
+  - `test_api_admin_permissions_list` already asserts 200 — no change.
+- [ ] Add `test_api_admin_permission_crud_roundtrip`: POST `/api/admin/permissions/add` with `{"code": "test.roundtrip.perm", "description": "d", "sortingCode": "Z9"}` → 200 + `permissionId`; edit it via `/api/admin/permissions/edit/<id>` (change description) → 200; verify via `db_conn` SELECT that Code and SortingCode round-tripped **with case preserved**; finally DELETE `/api/admin/permissions/delete/<id>` → 200 — the delete is the cleanup, wrap add→…→delete in `try/finally` so a mid-test failure still deletes.
+- [ ] Run the integration file against the reset NEXORA_TEST; all green (these now exercise the SortingCode paths for real).
+- [ ] Commit (`test(admin): permission APIs must not 500 — strict statuses + CRUD round-trip`).
+
+## Task 5 — Close the add-user authz gap
+
+- [ ] Failing tests first, in `tests/integration/test_admin_routes.py`. **Patch the view-module binding** (see Context):
+  - **Deny path:** `monkeypatch.setattr("nx_lib.views.admin.has_permission", lambda code: not code.startswith("admin.assign.user.accessprofile."))` — the `@require_permission("admin.create.user")` decorator still passes because it resolves the REAL `nx_lib.security.has_permission` and TestAdmin is seeded with every permission. POST the add-user route (find the exact path from `admin_add_user`'s registration in `admin.py`; the existing `test_admin_add_user_duplicate_returns_409_or_500` shows a working request body) with `"accessprofile": "TestUser"` → **assert 403** and via `db_conn` that no user row was created.
+  - **Allow path:** `monkeypatch.setattr("nx_lib.views.admin.has_permission", lambda code: True)` (do NOT rely on `admin_all_perms` — it cannot reach the inline gate), same POST with a unique username → 200; clean up via the app's admin user-delete route in `try/finally`.
+- [ ] **Update the existing test** `test_admin_add_user_duplicate_returns_409_or_500`: add the same `monkeypatch.setattr("nx_lib.views.admin.has_permission", lambda code: True)` so it keeps exercising the duplicate-409 path instead of dying on the new 403 (no `admin.assign.*` rows exist in the seed).
+- [ ] Implement in `admin_add_user`: insert the gate **immediately after the `if not all([...])` guard** — before the bcrypt hash and before any DB connection is opened (unlike `admin_edit_user`, no cursor is needed for the check):
+
+```python
+if not has_permission(f"admin.assign.user.accessprofile.{str(accessprofile).lower()}"):
+    current_app.logger.error(
+        "assign-permission denied: profile=%r username=%r",
+        str(accessprofile)[:100],
+        str(username)[:100],
+    )
+    return jsonify({"success": False, "message": _("Permission Denied for this action.")}), 403
+```
+
+(Parameterized `%r` logging on purpose — the values are request-controlled; do not switch to an f-string.)
+- [ ] Run the integration file; green. Commit (`fix(admin): enforce assign-profile permission on user creation`) — body notes this closes the **add-user** escalation path for `admin.create.user` holders (user-override and profile editors remain separately-gated trust boundaries).
+
+## Task 6 — Changelog + docs
+
+- [ ] `CHANGELOG.md` under `[Unreleased]`: **Fixed** — camelCase-named access profiles (e.g. `pdbsUser`) were unassignable even when granted (case-mismatch vs the lowercased check; permission matching is now case-insensitive and the stray row is normalized by migration `0034`); **Fixed** — admin permission add/edit and the user all-permissions API returned 500 everywhere (missing `Permission.SortingCode`, added by `0034`); **Fixed/Security** — user creation now enforces `admin.assign.user.accessprofile.<profile>` like user edit already did.
+- [ ] Grep `docs/` for `accessprofile` / permission-admin howtos; if any page documents permission-code conventions or the admin UI, add the "codes are lowercase by convention; matching is case-insensitive; `*.filter.process.*` tails are case-significant" note. If none exists, skip — do not author a new doc.
+- [ ] Commit (`docs(changelog): pdbsUser assign fix + permission API repairs`) — or fold into Task 5's commit.
+
+## Task 7 — Live verification on INT (browser, self-driven)
+
+- [ ] Restart the dev server: `nx -u -b --loginas:ben.streich` (INT). Playwright: open Admin → Access Control (and the user-detail page of any user).
+- [ ] Assert `pdbsUser` now appears in the access-profile dropdown of the **add-user** modal and the **edit-user** panel (it was absent before the fix).
+- [ ] Create a throwaway user with profile `pdbsUser` end-to-end → success; then delete the user via the admin UI.
+- [ ] In Access Control's permission manager, add a throwaway permission (any code) → verify the API no longer 500s and the row appears; delete it.
+- [ ] Screenshots of the dropdown + created user to `var/screenshots/pdbsuser-assign-*.png`; SendUserFile them if the session is remote.
+
+## Owner actions (not for the executor)
+
+1. **PROD fix timing:** migration `0034` reaches PROD automatically on the next deploy (merge to main). To fix PROD immediately instead: `python scripts/db-migrate.py --env PROD` from a SQL-reachable box (idempotent; it will also record `0032`, which is safe — its rows already exist by hand). Optional sanity: `SELECT DATABASEPROPERTYEX(DB_NAME(),'Collation')` on PROD should report a `_CI_` collation like INT's `SQL_Latin1_General_CP1_CI_AS`.
+2. After deploy, spot-check on PROD: assign `pdbsUser` to one user via the UI.
+3. Review + push `feature/2.5.64` (full pre-push gate).
+
+## Follow-ups deliberately NOT in this plan
+
+- Case-insensitive matching for the reporting raw-membership sites (`nx_lib/reporting/sources.py` `accessible()`, `nx_lib/reporting/runner.py`) — reporting source grants are their own machinery; touch only with reporting tests in hand.
+- `admin_edit_user` currently lets an assign-permission holder change the password of ANY existing user, including ones whose current profile they could not assign — consider requiring the assign permission for the target's CURRENT profile too. Separate spec-worthy discussion.
+- The stale header comment in `tests/integration/test_admin_routes.py` ("admin@test.local: admin.view + admin.users.manage + dashboard.view" — TestAdmin actually holds every seeded permission); fix opportunistically when editing that file.

--- a/nx_lib/hooks.py
+++ b/nx_lib/hooks.py
@@ -120,7 +120,7 @@ def _enforce_maintenance_lockout():
     if not blocking:
         return
     # Established session
-    if "admin.maintenance.bypass" in (session.get("permissions") or []):
+    if has_permission("admin.maintenance.bypass"):
         return
     # Mid-login flow (after bcrypt success, before perms are loaded into session)
     pending_uid = session.get("pre_2fa_userid") or session.get("pre_auth_userid")

--- a/nx_lib/security.py
+++ b/nx_lib/security.py
@@ -33,7 +33,7 @@ def load_permissions_for_user(user_id):
 
 def has_permission(code: str) -> bool:
     perms = set(session.get("permissions", []))
-    return code in perms
+    return code.lower() in {p.lower() for p in perms}
 
 
 def require_permission(code):

--- a/nx_lib/version.py
+++ b/nx_lib/version.py
@@ -6,4 +6,4 @@ sync with ``pyproject.toml`` ``[project].version`` — ``tests/unit/test_version
 enforces that they match.
 """
 
-__version__ = "2.5.63"
+__version__ = "2.5.64"

--- a/nx_lib/views/admin.py
+++ b/nx_lib/views/admin.py
@@ -679,6 +679,14 @@ def admin_add_user():
     if not all([username, password, fullname, email, organization, accessprofile]):
         return jsonify({"success": False, "message": _("All fields are required.")}), 400
 
+    if not has_permission(f"admin.assign.user.accessprofile.{str(accessprofile).lower()}"):
+        current_app.logger.error(
+            "assign-permission denied: profile=%r username=%r",
+            str(accessprofile)[:100],
+            str(username)[:100],
+        )
+        return jsonify({"success": False, "message": _("Permission Denied for this action.")}), 403
+
     hashed_password = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
     conn = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nexora"
 # Keep in sync with nx_lib/version.py (tests/unit/test_version.py enforces it).
-version = "2.5.63"
+version = "2.5.64"
 description = "Sydoc internal portal: workitems, invoices, chat, admin"
 requires-python = ">=3.13"
 readme = "README.md"

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -41,4 +41,4 @@ else
 fi
 
 echo "[pre-push] Running pytest..."
-exec "$PY" -m pytest tests -q --reruns 2 --only-rerun flaky_e2e
+exec "$PY" -m pytest tests -q

--- a/scripts/new-process.py
+++ b/scripts/new-process.py
@@ -1,0 +1,67 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import os
+
+# conn = engine_nexora_db.raw_connection()
+# cursor = conn.cursor()
+os.system("cls")
+
+print("==========[nexora].[dbo].[StatConfig]==========")
+print("\n! Please note that every input will be treated as case-sensitive")
+while True:
+    octo_client_name = input("\nocto client name: ")
+    octo_process_name = input("octo processname name: ")
+    octo_full_process_name = octo_client_name + "." + octo_process_name
+
+    stat_table = input("statistic tablename (f: schema.table): ")
+    add_cond = input("additional condition for stat: ")
+    export_column = input("export column: ")
+    import_column = input("import column: ")
+    workitem_column = input("workitem column: ")
+
+    while True:
+        client_code = input("is the new client ms? (y/n): ")
+
+        if client_code not in ("y", "n"):
+            print("y or n")
+            continue
+        else:
+            client_code = "ms02" if client_code == "y" else "default"
+            break
+
+    from tabulate import tabulate
+
+    print(
+        tabulate(
+            [
+                ["Process Name", octo_full_process_name],
+                ["Table Name", stat_table],
+                ["Additional Condition", add_cond],
+                ["Export Column", export_column],
+                ["Import Column", import_column],
+                ["Workitem Column", workitem_column],
+                ["Client Code", client_code],
+            ],
+            headers=["InputIn", "InputOut"],
+        )
+    )
+
+    confirm = input("confirm (y/n): ")
+    if confirm != "y":
+        continue
+
+    add_cond = "null" if add_cond in (None, "") else add_cond
+    query = f"INSERT INTO StatConfig(ProcessName, TableName, ExportColumn, additionalCondition, ImportColumn, WorkitemColumn, ClientCode) VALUES({octo_full_process_name, stat_table, export_column, add_cond, import_column, workitem_column, client_code})"
+    print(query)
+    # try:
+    #     cursor.execute(f"INSERT INTO StatConfig(ProcessName, TableName, ExportColumn, additionalCondition, ImportColumn, WorkitemColumn, ClientCode) VALUES(?,?,?,?,?,?,?)"
+    #                 , (octo_full_process_name, stat_table, export_column, add_cond, import_column, workitem_column, client_code))
+    #     conn.commit()
+    # except Exception as e:
+    #     print("Exception occured: " + e)
+    #
+
+    # cursor.close()
+    # conn.close()

--- a/sql/NexoraDB/Tables/dbo.Permission.sql
+++ b/sql/NexoraDB/Tables/dbo.Permission.sql
@@ -10,6 +10,7 @@ CREATE TABLE [dbo].[Permission](
 	[PermissionID] [int] IDENTITY(1,1) NOT NULL,
 	[Code] [sysname] NOT NULL,
 	[Description] [nvarchar](200) NOT NULL,
+	[SortingCode] [nvarchar](50) NULL,
 PRIMARY KEY CLUSTERED 
 (
 	[PermissionID] ASC

--- a/sql/_migrations/NexoraDB/0032_ignore_pdbs_deletion_marker_activities.sql
+++ b/sql/_migrations/NexoraDB/0032_ignore_pdbs_deletion_marker_activities.sql
@@ -1,0 +1,16 @@
+-- 0032_ignore_pdbs_deletion_marker_activities.sql
+-- Ignore the PDBS deletion-marker activity instances so they drop out of stats.
+-- Idempotent: skip each row that already exists.
+
+INSERT INTO dbo.ActivityInstancesToIgnore (ProcessName, ActivityInstanceName)
+SELECT v.ProcessName, v.ActivityInstanceName
+FROM (VALUES
+    ('sydoc.05_PDBS', 'Deletion Marker PDBS Parent Batch Deletion'),
+    ('sydoc.05_PDBS', 'Deletion Marker PDBS Deckblatt')
+) AS v(ProcessName, ActivityInstanceName)
+WHERE NOT EXISTS (
+    SELECT 1 FROM dbo.ActivityInstancesToIgnore a
+    WHERE a.ProcessName = v.ProcessName
+      AND a.ActivityInstanceName = v.ActivityInstanceName
+);
+GO

--- a/sql/_migrations/NexoraDB/0034_permission_sortingcode_and_pdbsuser_case.sql
+++ b/sql/_migrations/NexoraDB/0034_permission_sortingcode_and_pdbsuser_case.sql
@@ -1,0 +1,17 @@
+-- 0034_permission_sortingcode_and_pdbsuser_case.sql
+-- 1) dbo.Permission.SortingCode: referenced by the admin permission APIs
+--    (api_admin_permission_add/edit, api_admin_user_all_permissions) since the
+--    April admin redesign, but the column was never migrated -> those routes 500.
+-- 2) Normalize the one hand-inserted mixed-case assign code to the lowercase
+--    convention the app checks (admin.py builds codes with .lower()).
+-- Idempotent: guarded / naturally re-runnable. LOWER() makes the match
+-- collation-proof (CI or CS).
+
+IF COL_LENGTH('dbo.Permission', 'SortingCode') IS NULL
+    ALTER TABLE dbo.Permission ADD SortingCode nvarchar(50) NULL;
+GO
+
+UPDATE dbo.Permission
+SET Code = 'admin.assign.user.accessprofile.pdbsuser'
+WHERE LOWER(Code) = 'admin.assign.user.accessprofile.pdbsuser';
+GO

--- a/sql/test/schema.sql
+++ b/sql/test/schema.sql
@@ -54,7 +54,8 @@ GO
 CREATE TABLE dbo.Permission (
     PermissionID INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
     Code SYSNAME NOT NULL UNIQUE,
-    Description NVARCHAR(200) NOT NULL
+    Description NVARCHAR(200) NOT NULL,
+    SortingCode nvarchar(50) NULL
 );
 GO
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -23,14 +23,22 @@ E2E_RERUNS_DELAY = 1
 
 
 def pytest_collection_modifyitems(config, items):
-    """Apply pytest-rerunfailures reruns to every flaky_e2e-marked test.
+    """Apply pytest-rerunfailures reruns to every E2E test.
 
-    The flaky_e2e marker was previously decorative (no --reruns in addopts).
-    Scoping reruns here keeps them confined to E2E tests so unit/integration
-    failures still fail fast and loud.
+    Scoped by directory, not by the flaky_e2e marker: E2E flakes come from
+    real timing (network-idle waits, TOTP roll-over, server warm-up), which
+    affects every browser test, and 40+ tests had silently drifted out of the
+    net because their authors forgot the decorator. Unit/integration tests
+    are untouched and still fail fast and loud. The flaky_e2e marker remains
+    registered as documentation only.
+
+    (The gates' old ``--reruns 2 --only-rerun flaky_e2e`` CLI flags never
+    retried anything: --only-rerun is an error-text regex, and no traceback
+    ever contains the string "flaky_e2e".)
     """
+    e2e_dir = Path(__file__).parent
     for item in items:
-        if item.get_closest_marker("flaky_e2e"):
+        if e2e_dir in item.path.parents:
             item.add_marker(pytest.mark.flaky(reruns=E2E_RERUNS, reruns_delay=E2E_RERUNS_DELAY))
 
 

--- a/tests/e2e/test_reporting_simple.py
+++ b/tests/e2e/test_reporting_simple.py
@@ -3,6 +3,7 @@
 import json
 import re
 
+import pytest
 from playwright.sync_api import expect
 
 
@@ -1412,6 +1413,7 @@ def test_advanced_ai_ask_shows_loading(nexora_server, page):
     page.screenshot(path="var/screenshots/reporting_advanced_ai_loading.png")
 
 
+@pytest.mark.flaky_e2e
 def test_simple_export_csv(nexora_server, page):
     """The Simple export control downloads CSV when the format select says so."""
     _login(page, nexora_server)

--- a/tests/integration/test_admin_routes.py
+++ b/tests/integration/test_admin_routes.py
@@ -29,6 +29,8 @@ Sections:
 - /api/admin/permissions/*  CRUD
 """
 
+import uuid
+
 import pytest
 
 
@@ -196,8 +198,17 @@ def test_admin_add_user_missing_fields_returns_400(admin_client, admin_all_perms
     assert resp.status_code == 400
 
 
-def test_admin_add_user_duplicate_returns_409_or_500(admin_client, admin_all_perms):
-    """Re-add user@test.local → IntegrityError 409."""
+def test_admin_add_user_duplicate_returns_409_or_500(admin_client, admin_all_perms, monkeypatch):
+    """Re-add user@test.local → IntegrityError 409.
+
+    admin_all_perms only patches nx_lib.security.has_permission (reached by the
+    @require_permission decorator's dynamic lookup); it does NOT reach the
+    inline admin.assign.user.accessprofile.* gate added to admin_add_user,
+    which resolves nx_lib.views.admin.has_permission (bound at import time).
+    Patch that binding too so this test keeps exercising the duplicate-409
+    path instead of newly dying on the 403 gate.
+    """
+    monkeypatch.setattr("nx_lib.views.admin.has_permission", lambda code: True)
     resp = admin_client.post(
         "/admin/users/add",
         json={
@@ -210,6 +221,78 @@ def test_admin_add_user_duplicate_returns_409_or_500(admin_client, admin_all_per
         },
     )
     assert resp.status_code in (200, 409, 500)
+
+
+def test_admin_add_user_without_assign_permission_returns_403(admin_client, monkeypatch, db_conn):
+    """admin.create.user alone must not be enough to assign an access profile.
+
+    The @require_permission("admin.create.user") decorator resolves the REAL
+    nx_lib.security.has_permission at call time — TestAdmin (admin@test.local)
+    is seeded with every permission, so that check still passes. Only the
+    inline admin.assign.user.accessprofile.<profile> gate is denied here, by
+    patching the nx_lib.views.admin module-level binding (the one the inline
+    call inside admin_add_user actually resolves — patching
+    nx_lib.security.has_permission would NOT reach it).
+    """
+    from sqlalchemy import text
+
+    monkeypatch.setattr(
+        "nx_lib.views.admin.has_permission",
+        lambda code: not code.startswith("admin.assign.user.accessprofile."),
+    )
+    username = "task5-deny@test.local"
+    resp = admin_client.post(
+        "/admin/users/add",
+        json={
+            "username": username,
+            "password": "X",
+            "fullname": "Y",
+            "email": username,
+            "organization": "Test Organization",
+            "accessprofile": "TestUser",
+        },
+    )
+    assert resp.status_code == 403
+
+    count = db_conn.execute(
+        text("SELECT COUNT(*) FROM Users WHERE username = :u"), {"u": username}
+    ).scalar()
+    assert count == 0
+
+
+def test_admin_add_user_with_assign_permission_returns_200(admin_client, monkeypatch, db_conn):
+    """Holding the assign-permission (in addition to admin.create.user) allows creation.
+
+    Deliberately does NOT use admin_all_perms — that fixture patches
+    nx_lib.security.has_permission, which the inline gate in admin_add_user
+    (bound as nx_lib.views.admin.has_permission at import time) cannot see.
+    """
+    from sqlalchemy import text
+
+    monkeypatch.setattr("nx_lib.views.admin.has_permission", lambda code: True)
+    username = f"task5-allow-{uuid.uuid4().hex[:8]}@test.local"
+    user_id = None
+    try:
+        resp = admin_client.post(
+            "/admin/users/add",
+            json={
+                "username": username,
+                "password": "X",
+                "fullname": "Y",
+                "email": username,
+                "organization": "Test Organization",
+                "accessprofile": "TestUser",
+            },
+        )
+        assert resp.status_code == 200
+
+        user_id = db_conn.execute(
+            text("SELECT userID FROM Users WHERE username = :u"), {"u": username}
+        ).scalar()
+        assert user_id is not None
+    finally:
+        if user_id is not None:
+            admin_client.delete(f"/admin/users/delete/{user_id}")
 
 
 def test_admin_edit_user_nonexistent(admin_client, admin_all_perms):

--- a/tests/integration/test_admin_routes.py
+++ b/tests/integration/test_admin_routes.py
@@ -394,7 +394,7 @@ def test_api_admin_permission_crud_roundtrip(admin_client, admin_all_perms, db_c
 
     add_resp = admin_client.post(
         "/api/admin/permissions/add",
-        json={"code": "test.roundtrip.perm", "description": "d", "sortingCode": "Z9"},
+        json={"code": "Test.RoundTrip.Perm", "description": "d", "sortingCode": "Z9"},
     )
     assert add_resp.status_code == 200
     perm_id = add_resp.get_json()["permissionId"]
@@ -404,7 +404,7 @@ def test_api_admin_permission_crud_roundtrip(admin_client, admin_all_perms, db_c
         edit_resp = admin_client.post(
             f"/api/admin/permissions/edit/{perm_id}",
             json={
-                "code": "test.roundtrip.perm",
+                "code": "Test.RoundTrip.Perm",
                 "description": "d-updated",
                 "sortingCode": "Z9",
             },
@@ -415,7 +415,7 @@ def test_api_admin_permission_crud_roundtrip(admin_client, admin_all_perms, db_c
             text("SELECT Code, SortingCode, Description FROM Permission WHERE PermissionID = :pid"),
             {"pid": perm_id},
         ).one()
-        assert row.Code == "test.roundtrip.perm"
+        assert row.Code == "Test.RoundTrip.Perm"
         assert row.SortingCode == "Z9"
         assert row.Description == "d-updated"
     finally:

--- a/tests/integration/test_admin_routes.py
+++ b/tests/integration/test_admin_routes.py
@@ -354,27 +354,70 @@ def test_api_admin_permission_users_seeded(admin_client, admin_all_perms, db_con
 
 
 def test_api_admin_user_all_permissions(admin_client, admin_all_perms, db_conn):
+    """Permission.SortingCode exists (Task 1) so this no longer 500s."""
     from sqlalchemy import text
 
     uid = db_conn.execute(
         text("SELECT userID FROM Users WHERE username = 'admin@test.local'")
     ).scalar()
     resp = admin_client.get(f"/api/admin/users/{uid}/all_permissions")
-    assert resp.status_code in (200, 500)
+    assert resp.status_code == 200
 
 
 def test_api_admin_permission_add_missing_body(admin_client, admin_all_perms):
     resp = admin_client.post("/api/admin/permissions/add", json={})
-    assert resp.status_code in (200, 400, 500)
+    assert resp.status_code == 400
 
 
 def test_api_admin_permission_edit_unknown(admin_client, admin_all_perms):
+    """PermissionID 999999 doesn't exist -> UPDATE affects 0 rows -> 404."""
     resp = admin_client.post(
         "/api/admin/permissions/edit/999999", json={"code": "x.y", "description": "d"}
     )
-    assert resp.status_code in (200, 404, 500)
+    assert resp.status_code == 404
 
 
 def test_api_admin_permission_delete_unknown(admin_client, admin_all_perms):
+    """PermissionID 999999 doesn't exist -> DELETE affects 0 rows -> 404."""
     resp = admin_client.delete("/api/admin/permissions/delete/999999")
-    assert resp.status_code in (200, 404, 500)
+    assert resp.status_code == 404
+
+
+def test_api_admin_permission_crud_roundtrip(admin_client, admin_all_perms, db_conn):
+    """Add -> edit -> verify Code/SortingCode round-trip with case preserved -> delete.
+
+    Exercises the SortingCode column end-to-end (Task 1 added it to Permission;
+    this proves add/edit persist it correctly and that Code/SortingCode are
+    never lowercased, since *.filter.process.* codes elsewhere are case-significant).
+    """
+    from sqlalchemy import text
+
+    add_resp = admin_client.post(
+        "/api/admin/permissions/add",
+        json={"code": "test.roundtrip.perm", "description": "d", "sortingCode": "Z9"},
+    )
+    assert add_resp.status_code == 200
+    perm_id = add_resp.get_json()["permissionId"]
+    assert perm_id
+
+    try:
+        edit_resp = admin_client.post(
+            f"/api/admin/permissions/edit/{perm_id}",
+            json={
+                "code": "test.roundtrip.perm",
+                "description": "d-updated",
+                "sortingCode": "Z9",
+            },
+        )
+        assert edit_resp.status_code == 200
+
+        row = db_conn.execute(
+            text("SELECT Code, SortingCode, Description FROM Permission WHERE PermissionID = :pid"),
+            {"pid": perm_id},
+        ).one()
+        assert row.Code == "test.roundtrip.perm"
+        assert row.SortingCode == "Z9"
+        assert row.Description == "d-updated"
+    finally:
+        del_resp = admin_client.delete(f"/api/admin/permissions/delete/{perm_id}")
+        assert del_resp.status_code == 200

--- a/tests/integration/test_admin_routes.py
+++ b/tests/integration/test_admin_routes.py
@@ -269,6 +269,8 @@ def test_admin_add_user_with_assign_permission_returns_200(admin_client, monkeyp
     """
     from sqlalchemy import text
 
+    from nx_lib.db import engine_nexora_db
+
     monkeypatch.setattr("nx_lib.views.admin.has_permission", lambda code: True)
     username = f"task5-allow-{uuid.uuid4().hex[:8]}@test.local"
     user_id = None
@@ -291,8 +293,38 @@ def test_admin_add_user_with_assign_permission_returns_200(admin_client, monkeyp
         ).scalar()
         assert user_id is not None
     finally:
+        # NOTE: cleanup deliberately does NOT go through admin_client.delete(...)
+        # or db_conn, even though the general convention for this file is to
+        # clean up via the app's own delete routes:
+        #   - admin_delete_user (nx_lib/views/admin.py) deletes from `tags`,
+        #     `workitem_metadata`, `notifications`, etc. BEFORE it ever reaches
+        #     `DELETE FROM users`. None of those tables exist in the minimal
+        #     NEXORA_TEST schema (sql/test/schema.sql) — see the module
+        #     docstring's "Tables ABSENT" list and
+        #     test_admin_delete_user_missing_returns_404_or_500, which already
+        #     tolerates the resulting 500. So the route raises on its first
+        #     statement, is caught by a broad except, returns 500, and never
+        #     deletes the Users row — calling it here would silently no-op.
+        #   - db_conn's writes are rolled back at end-of-test (see its fixture
+        #     docstring in tests/conftest.py), so a DELETE issued through it
+        #     would never actually persist either.
+        # A direct delete on a separate, explicitly-committed connection — the
+        # same approach used to clear the RED-phase leftover row (see
+        # task-5-report.md) — is the only way that actually removes the row.
         if user_id is not None:
-            admin_client.delete(f"/admin/users/delete/{user_id}")
+            conn = engine_nexora_db.raw_connection()
+            try:
+                cur = conn.cursor()
+                cur.execute("DELETE FROM Users WHERE userID = ?", [user_id])
+                conn.commit()
+                cur.close()
+            finally:
+                conn.close()
+
+            remaining = db_conn.execute(
+                text("SELECT COUNT(*) FROM Users WHERE userID = :uid"), {"uid": user_id}
+            ).scalar()
+            assert remaining == 0
 
 
 def test_admin_edit_user_nonexistent(admin_client, admin_all_perms):

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -267,6 +267,22 @@ def test_enforce_maintenance_lockout_bypass_perm_passes(app):
         assert _enforce_maintenance_lockout() is None
 
 
+def test_enforce_maintenance_lockout_bypass_perm_passes_mixed_case(app):
+    """Routed through has_permission() (Task 3), so a mixed-case permission
+    string stored in the session (e.g. from a differently-cased DB seed)
+    still grants the bypass instead of forcing the user out."""
+    with (
+        app.test_request_context("/dashboard"),
+        patch.object(
+            hooks_mod,
+            "_get_blocking_maintenance",
+            return_value={"id": 1, "title": "x"},
+        ),
+    ):
+        session["permissions"] = ["Admin.Maintenance.Bypass"]
+        assert _enforce_maintenance_lockout() is None
+
+
 def test_enforce_maintenance_lockout_mid_login_bypass(app):
     with (
         app.test_request_context("/dashboard"),

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -42,6 +42,35 @@ def test_has_permission_returns_false_when_no_permissions_in_session():
         assert has_permission("admin.view") is False
 
 
+def test_has_permission_matches_when_session_code_has_mixed_case():
+    # Live INT data pre-fix: Permission.Code stored as
+    # "admin.assign.user.accessprofile.pdbsUser" (mixed case), while the app
+    # checks the all-lowercase code — must match despite the case mismatch.
+    with patch(
+        "nx_lib.security.session",
+        {"permissions": ["admin.assign.user.accessprofile.pdbsUser"]},
+    ):
+        assert has_permission("admin.assign.user.accessprofile.pdbsuser") is True
+
+
+def test_has_permission_matches_when_checked_code_has_mixed_case():
+    # Reverse direction: session holds the lowercase code, caller checks with
+    # different casing.
+    with patch(
+        "nx_lib.security.session",
+        {"permissions": ["admin.assign.user.accessprofile.pdbsuser"]},
+    ):
+        assert has_permission("admin.assign.user.accessprofile.PDBSUSER") is True
+
+
+def test_has_permission_returns_false_for_genuinely_absent_code():
+    with patch(
+        "nx_lib.security.session",
+        {"permissions": ["admin.assign.user.accessprofile.pdbsUser"]},
+    ):
+        assert has_permission("admin.assign.user.accessprofile.someOtherRole") is False
+
+
 # ---------------------------------------------------------------------------
 # PermissionDenied
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ships the pdbsUser access-profile bugfix set plus a test-infrastructure repair found while shipping it.

- **pdbsUser unassignable in admin UI** — the hand-inserted permission code `admin.assign.user.accessprofile.pdbsUser` never matched the lowercased code the app checks, so the profile was silently filtered out of every assignable-profiles dropdown. `has_permission()` is now case-insensitive and migration `0034` normalizes the stray row.
- **Permission add/edit + user-all-permissions APIs 500'd everywhere** — they referenced `dbo.Permission.SortingCode`, which never existed. Migration `0034` adds it.
- **Security: privilege-escalation gap closed** — `admin_add_user` never checked the assign-profile permission, so any `admin.create.user` holder could create a user with ANY profile (incl. `enterpriseAdmin`) via direct POST. Now gated the same way `admin_edit_user` already was; deny-path test proves 403 + zero rows persisted.
- **Flaky-E2E retry net was dead plumbing** — the gates passed `--only-rerun flaky_e2e`, but that flag is an error-text regex (no traceback contains that string), so no test was ever retried and a single browser race failed the whole pre-push/CI run. Retries are now armed directory-wide in `tests/e2e/conftest.py` (40+ tests had also drifted out of the net by missing the marker); dead flags removed from the pre-commit gate, `deploy.yml`, `README.md`, and the legacy hook script.

Also on the branch from cycle-open: version bump to 2.5.64, migration `0032` (PDBS deletion-marker ignore rows, idempotent), `scripts/new-process.py` WIP helper (dev-only), Claude tooling chores.

## Migrations

`0032` + `0034` auto-apply to PROD on deploy before the app pool stops. Both are idempotent / safe if rows already exist by hand.

## Verification

- Full pre-push suite green at push time (1345 tests incl. Playwright e2e).
- Retry-net fix proven empirically with a fail-once probe: 0 retries under the old flags, 1 retry without them.
- Live INT browser verification 4/4: pdbsUser present in add-user and edit-user dropdowns; throwaway user create+delete; throwaway permission add+delete with no 500s.
- Whole-branch review (opus): no Critical, no Important findings.

## Post-deploy

- Spot-check on PROD: assign `pdbsUser` to one user via the admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Hp61o7h36y5RnajY6UBoX