### PR TITLE
fix: v3.1.2 hotfix — Generali edit/delete dead on PROD under the v3.1 CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Work toward the next release.
 
+## [3.1.2] - 2026-08-18
+
+### Fixed
+
+- **Generali edit/delete row buttons were dead on PROD since v3.1** (base
+  services, additional services, PDQM, project management). The #193
+  finding-10 CSP hardening removed `'unsafe-inline'` from `script-src`, and
+  these four partials still built their row buttons with inline
+  `onclick="openEditModal(...)"` handlers — which the browser refuses under
+  that CSP ("Refused to execute inline event handler"), so clicking did
+  nothing and the PUT/DELETE never left the browser. Invisible on dev/INT,
+  where Talisman (and thus the CSP) is deliberately off. The buttons now use
+  `data-id` + one delegated tbody listener per page (the same pattern the
+  reporting page already had, which is why reporting survived). A new
+  template lint (`tests/unit/test_no_inline_event_handlers.py`) fails on any
+  inline `on<event>=` handler so the PROD-only breakage can't ship again.
+
 ## [3.1.1] - 2026-08-18
 
 ### Added

--- a/nx_lib/version.py
+++ b/nx_lib/version.py
@@ -12,7 +12,7 @@ enforces that all three copies agree.
 
 # ponytail: bare "3.1" here — PEP 440 strips a leading "v", so the display "v"
 # lives in the two templates that render it, not in the version string.
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 
 try:
     # ponytail: nx_lib/_build.py is written by .github/workflows/deploy.yml right

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "nexora"
 # removed or made `dynamic`: uv refuses a [project] table without a static
 # version unless a build backend supplies one, and nexora is a virtual project
 # (never built or installed). tests/unit/test_version.py enforces the sync.
-version = "3.1.1"
+version = "3.1.2"
 description = "Sydoc internal portal: workitems, reporting, admin"
 requires-python = ">=3.13"
 readme = "README.md"

--- a/templates/js/_generali_additional_services_js.html
+++ b/templates/js/_generali_additional_services_js.html
@@ -150,8 +150,10 @@
         const deletable = canDeleteRecord(r);
         const showActions = canEdit || canDelete;
         let actionBtns = '';
-        if (canEdit)   actionBtns += `<button ${editable  ? `onclick="openEditModal(${r.id})"` : 'disabled'} class="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition mr-1 ${editable  ? 'text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50' : 'text-gray-300 cursor-not-allowed'}" data-testid="generali-additional-services-row-edit-${r.id}"><i class="fas fa-pen text-xs"></i></button>`;
-        if (canDelete) actionBtns += `<button ${deletable ? `onclick="deleteRecord(${r.id})"` : 'disabled'} class="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition ${deletable ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-gray-300 cursor-not-allowed'}" data-testid="generali-additional-services-row-delete-${r.id}"><i class="fas fa-trash text-xs"></i></button>`;
+        // #193 finding 10: onclick="" attribute handlers aren't nonce-covered by CSP —
+        // row actions go through the delegated tbody listener below instead.
+        if (canEdit)   actionBtns += `<button ${editable  ? '' : 'disabled'} class="edit-record-btn inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition mr-1 ${editable  ? 'text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50' : 'text-gray-300 cursor-not-allowed'}" data-id="${r.id}" data-testid="generali-additional-services-row-edit-${r.id}"><i class="fas fa-pen text-xs"></i></button>`;
+        if (canDelete) actionBtns += `<button ${deletable ? '' : 'disabled'} class="delete-record-btn inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition ${deletable ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-gray-300 cursor-not-allowed'}" data-id="${r.id}" data-testid="generali-additional-services-row-delete-${r.id}"><i class="fas fa-trash text-xs"></i></button>`;
         const actionsCell = showActions ? `<td class="px-4 py-3 text-center whitespace-nowrap">${actionBtns}</td>` : '';
 
         const tParent = translationsMap[r.parentCategory] || r.parentCategory || '—';
@@ -468,6 +470,13 @@
     }
 
     document.getElementById('cancelDeleteBtn').addEventListener('click', closeDeleteModal);
+
+    document.getElementById('attendanceTbody').addEventListener('click', function(e) {
+        const editBtn = e.target.closest('.edit-record-btn');
+        if (editBtn && !editBtn.disabled) { openEditModal(editBtn.dataset.id); return; }
+        const deleteBtn = e.target.closest('.delete-record-btn');
+        if (deleteBtn && !deleteBtn.disabled) deleteRecord(deleteBtn.dataset.id);
+    });
 
     document.getElementById('deleteModal').addEventListener('click', function(e) {
         if (e.target === this) closeDeleteModal();

--- a/templates/js/_generali_base_services_js.html
+++ b/templates/js/_generali_base_services_js.html
@@ -108,8 +108,10 @@
         const deletable = canDeleteRecord(r);
         const showActions = canEdit || canDelete;
         let actionBtns = '';
-        if (canEdit)   actionBtns += `<button ${editable  ? `onclick="openEditModal(${r.id})"` : 'disabled'} class="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition mr-1 ${editable  ? 'text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50' : 'text-gray-300 cursor-not-allowed'}" data-testid="generali-base-services-row-edit-${r.id}"><i class="fas fa-pen text-xs"></i></button>`;
-        if (canDelete) actionBtns += `<button ${deletable ? `onclick="deleteRecord(${r.id})"` : 'disabled'} class="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition ${deletable ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-gray-300 cursor-not-allowed'}" data-testid="generali-base-services-row-delete-${r.id}"><i class="fas fa-trash text-xs"></i></button>`;
+        // #193 finding 10: onclick="" attribute handlers aren't nonce-covered by CSP —
+        // row actions go through the delegated tbody listener below instead.
+        if (canEdit)   actionBtns += `<button ${editable  ? '' : 'disabled'} class="edit-record-btn inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition mr-1 ${editable  ? 'text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50' : 'text-gray-300 cursor-not-allowed'}" data-id="${r.id}" data-testid="generali-base-services-row-edit-${r.id}"><i class="fas fa-pen text-xs"></i></button>`;
+        if (canDelete) actionBtns += `<button ${deletable ? '' : 'disabled'} class="delete-record-btn inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition ${deletable ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-gray-300 cursor-not-allowed'}" data-id="${r.id}" data-testid="generali-base-services-row-delete-${r.id}"><i class="fas fa-trash text-xs"></i></button>`;
         const actionsCell = showActions ? `<td class="px-4 py-3 text-center whitespace-nowrap">${actionBtns}</td>` : '';
 
         return `<tr data-record-id="${r.id}" data-for-date="${r.forDate || ''}" data-category="${(r.category||'').replace(/"/g,'&quot;')}" data-effort="${r.effortInHours !== null ? r.effortInHours : ''}">
@@ -398,6 +400,13 @@
     document.getElementById('cancelDeleteBtn').addEventListener('click', closeDeleteModal);
     document.getElementById('deleteModal').addEventListener('click', function(e) {
         if (e.target === this) closeDeleteModal();
+    });
+
+    document.getElementById('recordsTbody').addEventListener('click', function(e) {
+        const editBtn = e.target.closest('.edit-record-btn');
+        if (editBtn && !editBtn.disabled) { openEditModal(editBtn.dataset.id); return; }
+        const deleteBtn = e.target.closest('.delete-record-btn');
+        if (deleteBtn && !deleteBtn.disabled) deleteRecord(deleteBtn.dataset.id);
     });
 
     document.getElementById('confirmDeleteBtn').addEventListener('click', function() {

--- a/templates/js/_generali_pdqm_js.html
+++ b/templates/js/_generali_pdqm_js.html
@@ -201,8 +201,10 @@
         const deletable = canDeleteRecord(r);
         const showActions = canEdit || canDelete;
         let actionBtns = '';
-        if (canEdit)   actionBtns += `<button ${editable  ? `onclick="openEditModal(${r.id})"` : 'disabled'} class="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition mr-1 ${editable  ? 'text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50' : 'text-gray-300 cursor-not-allowed'}" data-testid="generali-pdqm-row-edit-${r.id}"><i class="fas fa-pen text-xs"></i></button>`;
-        if (canDelete) actionBtns += `<button ${deletable ? `onclick="deleteRecord(${r.id})"` : 'disabled'} class="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition ${deletable ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-gray-300 cursor-not-allowed'}" data-testid="generali-pdqm-row-delete-${r.id}"><i class="fas fa-trash text-xs"></i></button>`;
+        // #193 finding 10: onclick="" attribute handlers aren't nonce-covered by CSP —
+        // row actions go through the delegated tbody listener below instead.
+        if (canEdit)   actionBtns += `<button ${editable  ? '' : 'disabled'} class="edit-record-btn inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition mr-1 ${editable  ? 'text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50' : 'text-gray-300 cursor-not-allowed'}" data-id="${r.id}" data-testid="generali-pdqm-row-edit-${r.id}"><i class="fas fa-pen text-xs"></i></button>`;
+        if (canDelete) actionBtns += `<button ${deletable ? '' : 'disabled'} class="delete-record-btn inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition ${deletable ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-gray-300 cursor-not-allowed'}" data-id="${r.id}" data-testid="generali-pdqm-row-delete-${r.id}"><i class="fas fa-trash text-xs"></i></button>`;
         const actionsCell = showActions ? `<td class="align-center whitespace-nowrap">${actionBtns}</td>` : '';
 
         const parentSubValue = r.parentSubCategory !== null && r.parentSubCategory !== undefined ? r.parentSubCategory : '';
@@ -605,6 +607,13 @@
     }
 
     document.getElementById('cancelDeleteBtn').addEventListener('click', closeDeleteModal);
+
+    document.getElementById('pdqmTbody').addEventListener('click', function(e) {
+        const editBtn = e.target.closest('.edit-record-btn');
+        if (editBtn && !editBtn.disabled) { openEditModal(editBtn.dataset.id); return; }
+        const deleteBtn = e.target.closest('.delete-record-btn');
+        if (deleteBtn && !deleteBtn.disabled) deleteRecord(deleteBtn.dataset.id);
+    });
 
     document.getElementById('deleteModal').addEventListener('click', function(e) {
         if (e.target === this) closeDeleteModal();

--- a/templates/js/_generali_project_management_js.html
+++ b/templates/js/_generali_project_management_js.html
@@ -83,8 +83,10 @@
         const deletable = canDeleteRecord(r);
         const showActions = canEdit || canDelete;
         let actionBtns = '';
-        if (canEdit)   actionBtns += `<button ${editable  ? `onclick="openEditModal(${r.id})"` : 'disabled'} class="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition mr-1 ${editable  ? 'text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50' : 'text-gray-300 cursor-not-allowed'}" data-testid="generali-project-management-row-edit-${r.id}"><i class="fas fa-pen text-xs"></i></button>`;
-        if (canDelete) actionBtns += `<button ${deletable ? `onclick="deleteRecord(${r.id})"` : 'disabled'} class="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition ${deletable ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-gray-300 cursor-not-allowed'}" data-testid="generali-project-management-row-delete-${r.id}"><i class="fas fa-trash text-xs"></i></button>`;
+        // #193 finding 10: onclick="" attribute handlers aren't nonce-covered by CSP —
+        // row actions go through the delegated tbody listener below instead.
+        if (canEdit)   actionBtns += `<button ${editable  ? '' : 'disabled'} class="edit-record-btn inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition mr-1 ${editable  ? 'text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50' : 'text-gray-300 cursor-not-allowed'}" data-id="${r.id}" data-testid="generali-project-management-row-edit-${r.id}"><i class="fas fa-pen text-xs"></i></button>`;
+        if (canDelete) actionBtns += `<button ${deletable ? '' : 'disabled'} class="delete-record-btn inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-lg transition ${deletable ? 'text-red-500 hover:text-red-700 hover:bg-red-50' : 'text-gray-300 cursor-not-allowed'}" data-id="${r.id}" data-testid="generali-project-management-row-delete-${r.id}"><i class="fas fa-trash text-xs"></i></button>`;
         const actionsCell = showActions ? `<td class="align-center whitespace-nowrap">${actionBtns}</td>` : '';
 
         const commentHtml = r.comment
@@ -370,6 +372,12 @@
     }
 
     document.getElementById('cancelDeleteBtn').addEventListener('click', closeDeleteModal);
+    document.getElementById('recordsTbody').addEventListener('click', function(e) {
+        const editBtn = e.target.closest('.edit-record-btn');
+        if (editBtn && !editBtn.disabled) { openEditModal(editBtn.dataset.id); return; }
+        const deleteBtn = e.target.closest('.delete-record-btn');
+        if (deleteBtn && !deleteBtn.disabled) deleteRecord(deleteBtn.dataset.id);
+    });
     document.getElementById('deleteModal').addEventListener('click', function(e) {
         if (e.target === this) closeDeleteModal();
     });

--- a/tests/unit/test_no_inline_event_handlers.py
+++ b/tests/unit/test_no_inline_event_handlers.py
@@ -1,0 +1,40 @@
+"""Template lint: no inline on<event>= attribute handlers (#193 finding 10).
+
+The PROD CSP has no 'unsafe-inline' in script-src and a script-src nonce does
+not cover attribute handlers, so any onclick=""/onchange=""/... in a template
+is silently refused by the browser on PROD — while dev/INT, where Talisman is
+off, keep working. That asymmetry shipped v3.1 with dead Generali edit/delete
+row buttons on four pages. Wire handlers with addEventListener (or delegation)
+instead; this test fails on any inline handler that sneaks back in.
+"""
+
+import re
+from pathlib import Path
+
+TEMPLATES = Path(__file__).resolve().parents[2] / "templates"
+
+# An on<event>= followed by a quote/backtick — matches HTML attributes and
+# attributes built inside JS template literals, but not `window.onclick = fn`.
+HANDLER = re.compile(
+    r"""\bon(click|dblclick|change|submit|input|load|error|keyup|keydown|keypress|"""
+    r"""mouseover|mouseout|mousedown|mouseup|mouseenter|mouseleave|blur|focus)\s*=\s*["'`]"""
+)
+
+
+def test_no_inline_event_handlers():
+    offenders = []
+    for path in sorted(TEMPLATES.rglob("*.html")):
+        if "archive" in path.parts:
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            stripped = line.lstrip()
+            # ponytail: line-based comment skip — enough for the /* … */ and
+            # {# … #} styles actually used in these templates.
+            if stripped.startswith(("//", "*", "/*", "{#", "<!--")):
+                continue
+            if HANDLER.search(line):
+                offenders.append(f"{path.relative_to(TEMPLATES)}:{lineno}: {stripped[:120]}")
+    assert not offenders, (
+        "Inline on<event>= handlers are refused by the PROD CSP (script-src has no "
+        "'unsafe-inline'); use addEventListener/delegation instead:\n" + "\n".join(offenders)
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -806,7 +806,7 @@ wheels = [
 
 [[package]]
 name = "nexora"
-version = "3.1.1"
+version = "3.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "bcrypt" },


### PR DESCRIPTION
## v3.1.2 hotfix

**Bug:** since the v3.1 deploy (Aug 17), the edit and delete row buttons on the Generali base services, additional services, PDQM and project management pages did nothing on PROD. No PUT/DELETE request ever left the browser (confirmed in both nexora request logs and IIS logs).

**Root cause:** the #193 finding-10 CSP hardening removed `'unsafe-inline'` from `script-src`, but these four partials still built their row buttons with inline `onclick="openEditModal(...)"` handlers — the browser refuses those under that CSP. Invisible on dev/INT because Talisman (and the CSP) only runs on PROD. The reporting page survived because it already used event delegation.

**Fix:** buttons now carry `data-id` + `edit-record-btn`/`delete-record-btn` classes with one delegated tbody listener per page (reporting's existing pattern).

**Guard:** new `tests/unit/test_no_inline_event_handlers.py` lints all templates and fails on any inline `on<event>=` handler.

**Verification:** local INT run with the PROD Talisman CSP applied on top — all five pages open the edit modal, base services round-trips a save (PUT 200), delete confirm modals appear, zero CSP refusals, zero remaining `onclick` buttons.

No migrations, no env-key changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJTAG8zST9ppxnwsgXT8SQ