### PR TITLE
ci(deploy): fix tab-mangled prod python path in the IIS preflight

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -257,9 +257,9 @@ jobs:
           if (-not (Get-WebGlobalModule | Where-Object Name -eq 'httpPlatformHandler')) {
             throw "IIS module 'httpPlatformHandler' is not installed on SYAPP01 -- install HttpPlatformHandler v1.2 x64 (docs/howto/iis.md) before deploying."
           }
-          D:\sydoc	ools\py\python.exe -c "import waitress; print('waitress', waitress.__version__)"
+          D:\sydoc\tools\py\python.exe -c "import waitress; print('waitress', waitress.__version__)"
           if ($LASTEXITCODE -ne 0) {
-            throw "waitress is not importable from D:\sydoc	ools\py -- the 'pip install -r requirements.txt' step above should have installed it."
+            throw "waitress is not importable from D:\sydoc\tools\py -- the 'pip install -r requirements.txt' step above should have installed it."
           }
 
       - name: Stop app pool and service


### PR DESCRIPTION
The `Preflight IIS host (HttpPlatformHandler + waitress)` step in `deploy.yml`
carried a **literal tab character** where `D:\sydoc\tools\py` belonged:

```
D:\sydoc<TAB>ools\py\python.exe -c "import waitress; ..."
```

PowerShell parsed `D:\sydoc` as the command name and the step died with
`CommandNotFoundException`. Pull requests never exercise it — the `deploy` job
is push-to-main only — so it first fired on the v3.2.3 merge
([run 33099091339](https://github.com/Sydoc-Code/nexora/actions/runs/33099091339)).

### PROD state after the failed run

The step order matters here. `Apply DB migrations to PROD` had already
succeeded; the preflight then failed **before** `Stop app pool and service` and
`Sync to deploy folder` ran. SYAPP01 is therefore still serving the previous
code against the v3.2.3 schema. Merging this re-runs the deploy and closes the
gap.

### Change

Two lines in `.github/workflows/deploy.yml` — tab restored to `\tools`.
No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6rWovbq6qeZVUNAqVGy8m