### PR TITLE
ci(deploy): probe waitress version via importlib.metadata

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -257,7 +257,7 @@ jobs:
           if (-not (Get-WebGlobalModule | Where-Object Name -eq 'httpPlatformHandler')) {
             throw "IIS module 'httpPlatformHandler' is not installed on SYAPP01 -- install HttpPlatformHandler v1.2 x64 (docs/howto/iis.md) before deploying."
           }
-          D:\sydoc\tools\py\python.exe -c "import waitress; print('waitress', waitress.__version__)"
+          D:\sydoc\tools\py\python.exe -c "import waitress, importlib.metadata as md; print('waitress', md.version('waitress'))"
           if ($LASTEXITCODE -ne 0) {
             throw "waitress is not importable from D:\sydoc\tools\py -- the 'pip install -r requirements.txt' step above should have installed it."
           }


### PR DESCRIPTION
Follow-up to #225. That PR fixed the tab-mangled interpreter path, which got
the preflight far enough to reveal the *next* problem in the same step:

```
AttributeError: module 'waitress' has no attribute '__version__'
```

`import waitress` succeeded — the package is installed and importable from
`D:\sydoc\tools\py`. But waitress exposes no `__version__` attribute, so the
probe raised, `$LASTEXITCODE` went non-zero, and the step threw its
(misleading) "waitress is not importable" error.

The check has never been able to pass. It shipped with v3.2.3 and only ran for
the first time on the v3.2.3 merge, since the `deploy` job is push-to-main only.

### Change

Ask the package metadata instead of the module:

```powershell
D:\sydoc\tools\py\python.exe -c "import waitress, importlib.metadata as md; print('waitress', md.version('waitress'))"
```

Still verifies the import, still logs the version, `importlib.metadata` is stdlib.
One line in `.github/workflows/deploy.yml`; no app code touched.

### PROD state

Unchanged from #225 and not made worse: the v3.2.3 migrations are applied to
PROD, but the preflight has died before `Stop app pool and service` on both
runs, so SYAPP01 is still serving the previous code against the new schema.
Merging this should carry the deploy through and close the gap.

Everything after the preflight is unchanged from the v3.2.2 deploy that
succeeded on 2026-08-25 — diffed `deploy.yml` against `78592ce8` and the
preflight step is the only genuinely new logic in the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6rWovbq6qeZVUNAqVGy8m