### PR TITLE
fix(scripts): test_db_reset must not hardcode ODBC Driver 17

### DIFF
--- a/scripts/test_db_reset.py
+++ b/scripts/test_db_reset.py
@@ -111,6 +111,25 @@ def execute_sql_file(cursor: pyodbc.Cursor, path: Path) -> None:
             ) from e
 
 
+def _pick_sqlserver_driver() -> str | None:
+    """Best installed SQL Server ODBC driver, newest first.
+
+    Mirrors what a developer would put in DB_ODBC_DRIVER by hand; the legacy
+    "SQL Server" driver is last because it lacks Encrypt/TrustServerCertificate
+    support (see the _TLS_SUFFIX note in nx_lib/db.py).
+    """
+    installed = pyodbc.drivers()
+    for candidate in (
+        "ODBC Driver 18 for SQL Server",
+        "ODBC Driver 17 for SQL Server",
+        "SQL Server Native Client 11.0",
+        "SQL Server",
+    ):
+        if candidate in installed:
+            return candidate
+    return None
+
+
 def main() -> int:
     if not TEST_ENV.exists():
         print(
@@ -147,13 +166,29 @@ def main() -> int:
             print(f"Missing: {p}", file=sys.stderr)
             return 1
 
-    # Use the same driver nexora itself uses. autocommit so each batch commits
-    # immediately (schema.sql can't run inside an explicit transaction anyway
-    # because it does CREATE/DROP).
-    conn_str = (
-        f"DRIVER={{ODBC Driver 17 for SQL Server}};"
-        f"SERVER={server};DATABASE={db};UID={uid};PWD={pwd};"
-    )
+    # Use the same driver nexora itself uses -- DB_ODBC_DRIVER from the env file,
+    # exactly like nx_lib/db.py, falling back to whatever SQL Server driver is
+    # actually installed. This used to hardcode "ODBC Driver 17 for SQL Server",
+    # which made the script unusable on any box that ships 18 (or only the legacy
+    # "SQL Server") even though its docstring promises it runs anywhere pyodbc
+    # does. autocommit so each batch commits immediately (schema.sql can't run
+    # inside an explicit transaction anyway because it does CREATE/DROP).
+    driver = env.get("DB_ODBC_DRIVER") or _pick_sqlserver_driver()
+    if not driver:
+        print(
+            "No SQL Server ODBC driver found. Install one, or set DB_ODBC_DRIVER "
+            f"in env/TEST.env. Available: {pyodbc.drivers()}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Driver 17/18 understand (and 18 defaults to requiring) TLS, and reject a
+    # self-signed server cert unless told to trust it. The legacy "SQL Server"
+    # driver errors on these keywords outright, so they're only added for the
+    # modern ones -- same conditional as _TLS_SUFFIX in nx_lib/db.py.
+    tls = "Encrypt=yes;TrustServerCertificate=yes;" if driver.startswith("ODBC Driver") else ""
+    conn_str = f"DRIVER={{{driver}}};SERVER={server};DATABASE={db};UID={uid};PWD={pwd};{tls}"
+    print(f"Using ODBC driver: {driver}")
     conn = pyodbc.connect(conn_str, autocommit=True)
     try:
         cursor = conn.cursor()


### PR DESCRIPTION
## What

`scripts/test_db_reset.py` hardcoded `ODBC Driver 17 for SQL Server` in its connection string, despite a docstring promising it "runs anywhere pyodbc does ... without needing SQL Server Command Line Tools installed".

On a machine that ships only Driver 18 (or just the legacy `SQL Server` driver) it failed with a bare `IM002` "data source name not found and no default driver specified" — so the TEST database could not be reset at all, and every permission-gated integration test was unrunnable.

## Fix

- Honour `DB_ODBC_DRIVER` from `env/TEST.env`, exactly as `nx_lib/db.py` does.
- Otherwise pick the newest installed driver (18 → 17 → Native Client → legacy).
- Add `Encrypt`/`TrustServerCertificate` for the modern drivers only — Driver 18 defaults to requiring TLS and rejects a self-signed server certificate, while the legacy driver errors on those keywords outright. Same conditional as `db.py`'s `_TLS_SUFFIX`.
- Print the driver actually chosen, so a future mismatch is obvious.

## Verified

Reset now completes on a Driver 18 machine:

```
Using ODBC driver: ODBC Driver 18 for SQL Server
Wiped NEXORA_TEST on INTSQL01 (18 tables, 2 views/procs/functions)
Applying schema to NEXORA_TEST on INTSQL01...
Applying seed to NEXORA_TEST on INTSQL01...
NEXORA_TEST reset complete.
```

## Why it is worth landing on its own

This blocked work twice in one session on branches that lacked the fix, including while diagnosing the #228 outage. Until it merges, anyone without Driver 17 cannot reset the test database — which is a prerequisite for the gate that currently blocks all deploys.

No dependencies; touches one file.
