### PR TITLE
fix(tests): blank both CSRF tokens when comparing reset-page responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ Work toward the next release.
   mapping tables only; INT never had the synonyms, so the migration is a
   no-op there.
 
+### Fixed
+
+- **A flaky auth test no longer reddens CI at random.**
+  `_without_csrf_token()` in `tests/integration/test_auth_routes.py` blanked
+  the CSRF token in the `<meta>` tag but not the one in the form's hidden
+  input, so the two "a registered and an unregistered address must look
+  identical" comparisons failed whenever their two requests straddled a
+  1-second boundary — the token is re-signed with an itsdangerous timestamp
+  of that granularity. Both spots are blanked now.
+
 ## [3.2.3] - 2026-08-27
 
 ### Added

--- a/tests/integration/test_auth_routes.py
+++ b/tests/integration/test_auth_routes.py
@@ -31,11 +31,15 @@ def _without_csrf_token(body):
     Flask-WTF re-signs the session's CSRF secret on every request with an
     itsdangerous timestamp, and those have 1-second granularity -- so two
     otherwise byte-identical responses rendered either side of a second
-    boundary differ, at exactly one place, by that token. It is per-request
+    boundary differ, everywhere that token is rendered. It is per-request
     noise, not part of the "a registered and an unregistered address must
     look identical" contract the callers are asserting.
     """
-    return re.sub(rb'(?<=name="csrf-token" content=")[^"]*', b"", body)
+    body = re.sub(rb'(?<=name="csrf-token" content=")[^"]*', b"", body)
+    # The page carries the same token twice: the <meta> tag above and the
+    # form's hidden input. Blanking only the first left the second to differ
+    # across a second boundary -- the exact flake this helper exists to stop.
+    return re.sub(rb'(?<=name="csrf_token" value=")[^"]*', b"", body)
 
 
 def _clear_reset_token_marker(client, token):


### PR DESCRIPTION
`_without_csrf_token()` in `tests/integration/test_auth_routes.py` blanked the CSRF token in the `<meta>` tag but not the copy in the form's hidden input (`templates/forgot_password.html:99`). Flask-WTF re-signs that token with an itsdangerous timestamp of 1-second granularity, so the two "a registered and an unregistered address must look identical" comparisons compared unequal whenever their two requests straddled a second boundary.

The helper's own docstring describes exactly this hazard — it just only covered one of the two places the token is rendered.

## Impact

Random CI reddening, on a test whose failure message points nowhere near the cause:

```
FAILED tests/integration/test_auth_routes.py::test_request_password_reset_returns_before_send_completes
  assert b'<!DOCTYPE h...ody>\n</html>' == b'<!DOCTYPE h...ody>\n</html>'
  At index 6225 diff: b'Q' != b'g'
```

That is what failed CI on #234, whose diff (`nx_lib/views/dashboard.py`, `nx_lib/field_locations.py`) cannot affect the forgot-password page. Both callers of the helper share the bug; the sibling `test_request_password_reset_known_and_unknown_email_same_response` has failed the same way.

## Verified

Rendering the page twice across a forced 1.1s gap — the straddle that was failing:

```
current helper (meta only) -> equal: False
  first diff at index 6224: b'...mU2MjRjMDRmOTllNzk0Mjk1M2FiY2RjNDE5OWI4NDlkNjg1MTc2MTgi.apW1Uw.Isu919z...'
with form token stripped   -> equal: True
```

The differing bytes are the itsdangerous-signed form token, at the index CI reported. `tests/integration/test_auth_routes.py` passes (42 tests), as does the full unit + integration tier via the pre-push gate.

## Note

The anti-enumeration contract itself is untouched — the two responses must still be byte-identical everywhere that is not per-request token noise. This only widens what counts as that noise, from one of the two rendered tokens to both.

Unrelated to #235 (the shared `NEXORA_TEST` database race), which is a separate source of random CI failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPcHu5FRCmxX4vR98vs1yo
