### PR TITLE
fix(tests): serialise runs on the shared NEXORA_TEST database (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,19 @@ Work toward the next release.
   leaves. The handler also logs a traceback, since the bare message named
   neither the file nor the workitem (#228 follow-up).
 
+- **Test runs no longer corrupt each other's shared database.** One
+  `NEXORA_TEST` is shared by CI and every local run, and both the pre-push gate
+  and CI's `test` job reset it — so two overlapping runs re-seeded `dbo.Users`
+  under one another and a random login fixture died with `KeyError: 'userid'`
+  or a stray 401. A different test each time, always passing in isolation,
+  never pointing at the cause; it cost five failed CI runs in one day and
+  blocked two PRs that were entirely correct. Both the reset script and the
+  pytest session now take an exclusive `sp_getapplock` on `nexora_test_suite`
+  (`scripts/db_lock.py`), so the second run waits instead of trampling.
+  `NEXORA_TEST_LOCK_SKIP=1` bypasses it, `NEXORA_TEST_LOCK_TIMEOUT_MS`
+  overrides the 20-minute wait, and a run that cannot reach the database
+  doesn't lock at all. See CONTRIBUTING.md and #235.
+
 ## [3.2.3] - 2026-08-27
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,42 @@ uv export --format requirements-txt --no-hashes          -o requirements-dev.txt
 `tests/unit/test_dependencies.py` fails if `nx_lib/`, `scripts/` or `ops/`
 imports a package that `pyproject.toml` does not declare.
 
+## The shared test database
+
+There is exactly one `NEXORA_TEST`, on `INTSQL01`, and CI and every developer's
+local run share it. Both the pre-push gate and CI's `test` job reset it, so two
+overlapping runs used to corrupt each other: whichever started second re-seeded
+`dbo.Users` under the one already going, and a random login fixture died with
+`KeyError: 'userid'` or a stray 401 — a different test every time, always
+passing in isolation, never pointing at the real cause (issue #235).
+
+Runs now serialise on a SQL Server application lock (`scripts/db_lock.py`).
+Both the reset script and the pytest session take `nexora_test_suite`
+exclusively, so a second run **waits** instead of trampling:
+
+```
+[db-lock] another test run holds nexora_test_suite; waiting up to 20 min (pytest).
+[db-lock] acquired after 47s
+```
+
+That wait is the feature — do not kill it. The lock is `@LockOwner='Session'`,
+so a killed run releases it when SQL Server reaps the session; there is never a
+stale lock to clear by hand.
+
+| Variable | Effect |
+|---|---|
+| `NEXORA_TEST_LOCK_SKIP=1` | Don't lock at all. For when the lock itself is the problem. |
+| `NEXORA_TEST_LOCK_TIMEOUT_MS` | Override the 20-minute wait before giving up. |
+
+Skipping means you can corrupt someone else's in-flight run, and they cannot
+tell it was you — so prefer waiting. A run that cannot reach the database
+doesn't lock at all (it can't corrupt anything either), which keeps pure-unit
+runs working offline.
+
+Do not use elapsed time to judge whether a run was contended. A brief collision
+reddens a suite without slowing it — the deploy that exposed this failed in
+3m54s, inside the normal ~5m.
+
 ## Naming conventions
 
 **Python:**

--- a/scripts/db_lock.py
+++ b/scripts/db_lock.py
@@ -1,0 +1,131 @@
+"""Serialise access to the shared NEXORA_TEST database (#235).
+
+There is exactly one NEXORA_TEST, on INTSQL01, shared by CI and every local
+test run. Both the pre-push gate and CI's `test` job start by resetting it, so
+an overlapping pair corrupts each other: whichever runs second re-seeds
+dbo.Users under the one already going, and a random login fixture dies with
+`KeyError: 'userid'` or a stray 401. The failure is never the same test twice
+and always passes in isolation, so it reads as "that test is flaky" rather
+than "something else is resetting your database".
+
+`sp_getapplock` makes the second runner WAIT instead of corrupting. The lock is
+taken with @LockOwner='Session', which ties it to the SQL session holding it:
+a killed run releases it when SQL Server reaps that session, so there is no
+stale lock to clear by hand.
+
+Wall-clock is NOT a reliable tell for contention -- a brief collision reddens a
+run without slowing it (the deploy of #231 failed in 3m54s, well inside the
+normal ~5m). That is why this is a lock and not a "check before you run" note.
+
+Escape hatch: NEXORA_TEST_LOCK_SKIP=1 disables locking entirely, mirroring the
+SQL_SYNC_SKIP=1 convention used by the pre-commit hooks.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from contextlib import contextmanager
+
+# Database-scoped: both parties connect to NEXORA_TEST, so they contend on the
+# same name. Anything else running against that database should use it too.
+RESOURCE = "nexora_test_suite"
+
+# A full CI tier is ~5 min and e2e ~12, so a peer can legitimately hold this
+# for a while. Long enough to queue behind one of those, short enough that a
+# genuinely wedged lock surfaces instead of hanging until someone notices.
+DEFAULT_TIMEOUT_MS = 20 * 60 * 1000
+
+SKIP_ENV = "NEXORA_TEST_LOCK_SKIP"
+TIMEOUT_ENV = "NEXORA_TEST_LOCK_TIMEOUT_MS"
+
+# sp_getapplock return codes. >= 0 means the lock is held.
+_GRANTED = {0: "granted", 1: "granted after waiting"}
+_REFUSED = {
+    -1: "timed out waiting for another test run to finish",
+    -2: "cancelled",
+    -3: "chosen as a deadlock victim",
+    -999: "parameter or call error",
+}
+
+
+def _timeout_ms(explicit: int | None) -> int:
+    if explicit is not None:
+        return explicit
+    raw = os.environ.get(TIMEOUT_ENV)
+    return int(raw) if raw and raw.isdigit() else DEFAULT_TIMEOUT_MS
+
+
+def _acquire(cursor, resource: str, timeout_ms: int) -> int:
+    cursor.execute(
+        "DECLARE @rc int; "
+        "EXEC @rc = sp_getapplock @Resource = ?, @LockMode = 'Exclusive', "
+        "@LockOwner = 'Session', @LockTimeout = ?; "
+        "SELECT @rc;",
+        resource,
+        timeout_ms,
+    )
+    return int(cursor.fetchone()[0])
+
+
+def _default_notify(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+@contextmanager
+def hold(
+    conn,
+    label: str = "test run",
+    resource: str = RESOURCE,
+    timeout_ms: int | None = None,
+    notify=_default_notify,
+):
+    """Hold the shared-database lock on `conn` for the duration of the block.
+
+    `conn` must be an autocommit DBAPI connection to NEXORA_TEST, and must stay
+    open for as long as the lock is needed -- the lock dies with its session.
+
+    Probes with a zero timeout first so that waiting for a peer prints a reason
+    rather than looking like a hang. `notify` exists because pytest captures
+    stderr by default -- conftest passes one that suspends capture, otherwise
+    the "waiting" line is swallowed and a 20-minute wait looks like a freeze.
+    """
+    if os.environ.get(SKIP_ENV) == "1":
+        notify(f"[db-lock] {SKIP_ENV}=1 -- not serialising ({label})")
+        yield "skipped"
+        return
+
+    total_ms = _timeout_ms(timeout_ms)
+    cursor = conn.cursor()
+
+    rc = _acquire(cursor, resource, 0)
+    if rc < 0:
+        mins = total_ms / 60000
+        notify(
+            f"[db-lock] another test run holds {resource}; waiting up to {mins:.0f} min "
+            f"({label}). Set {SKIP_ENV}=1 to bypass -- see issue #235."
+        )
+        waited = time.monotonic()
+        rc = _acquire(cursor, resource, total_ms)
+        if rc >= 0:
+            notify(f"[db-lock] acquired after {time.monotonic() - waited:.0f}s")
+
+    if rc < 0:
+        raise RuntimeError(
+            f"could not acquire {resource}: {_REFUSED.get(rc, f'sp_getapplock returned {rc}')}. "
+            f"Another test run is using NEXORA_TEST. Wait for it, raise {TIMEOUT_ENV}, "
+            f"or set {SKIP_ENV}=1 to run anyway (see issue #235)."
+        )
+
+    try:
+        yield _GRANTED.get(rc, "held")
+    finally:
+        try:
+            cursor.execute(
+                "EXEC sp_releaseapplock @Resource = ?, @LockOwner = 'Session';", resource
+            )
+        except Exception as e:
+            # Not fatal: the lock is session-scoped, so closing the connection
+            # (or SQL Server reaping it) frees it anyway.
+            notify(f"[db-lock] release failed, session close will free it: {e}")

--- a/scripts/test_db_reset.py
+++ b/scripts/test_db_reset.py
@@ -19,6 +19,15 @@ from pathlib import Path
 import pyodbc
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Run as a script (`python scripts/test_db_reset.py`) only scripts/ lands on
+# sys.path, not the repo root -- but tests/conftest.py imports this module as
+# scripts.test_db_reset. Put the root on the path so one import form works both
+# ways rather than duplicating the lock protocol in two places.
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import db_lock  # noqa: E402
+
 TEST_ENV = REPO_ROOT / "env" / "TEST.env"
 SCHEMA_SQL = REPO_ROOT / "sql" / "test" / "schema.sql"
 SEED_SQL = REPO_ROOT / "sql" / "test" / "seed.sql"
@@ -130,14 +139,25 @@ def _pick_sqlserver_driver() -> str | None:
     return None
 
 
-def main() -> int:
+class TestDbUnavailableError(RuntimeError):
+    """env/TEST.env is missing, misconfigured, or no SQL Server ODBC driver exists.
+
+    Carries a printable reason -- callers surface str(e) rather than a traceback.
+    """
+
+
+def connect_test_db() -> pyodbc.Connection:
+    """Autocommit pyodbc connection to NEXORA_TEST, built from env/TEST.env.
+
+    Shared with tests/conftest.py so the suite's shared-database lock (#235)
+    reaches the same server through the same driver selection as the reset --
+    two code paths picking different drivers would contend on nothing.
+    """
     if not TEST_ENV.exists():
-        print(
+        raise TestDbUnavailableError(
             f"env/TEST.env not found at {TEST_ENV}. "
-            "Copy env/TEST.env.example to env/TEST.env and fill in values.",
-            file=sys.stderr,
+            "Copy env/TEST.env.example to env/TEST.env and fill in values."
         )
-        return 1
 
     env = parse_env(TEST_ENV)
     server = env.get("DB_SERVER_PRD")
@@ -151,20 +171,12 @@ def main() -> int:
         if not v
     ]
     if missing:
-        print(f"TEST.env is missing: {', '.join(missing)}", file=sys.stderr)
-        return 1
+        raise TestDbUnavailableError(f"TEST.env is missing: {', '.join(missing)}")
 
     if db != "NEXORA_TEST":
-        print(
-            f"Refusing to run: DB_NEXORA in TEST.env must be 'NEXORA_TEST', got '{db}'.",
-            file=sys.stderr,
+        raise TestDbUnavailableError(
+            f"Refusing to run: DB_NEXORA in TEST.env must be 'NEXORA_TEST', got '{db}'."
         )
-        return 1
-
-    for p in (SCHEMA_SQL, SEED_SQL):
-        if not p.exists():
-            print(f"Missing: {p}", file=sys.stderr)
-            return 1
 
     # Use the same driver nexora itself uses -- DB_ODBC_DRIVER from the env file,
     # exactly like nx_lib/db.py, falling back to whatever SQL Server driver is
@@ -175,12 +187,10 @@ def main() -> int:
     # inside an explicit transaction anyway because it does CREATE/DROP).
     driver = env.get("DB_ODBC_DRIVER") or _pick_sqlserver_driver()
     if not driver:
-        print(
+        raise TestDbUnavailableError(
             "No SQL Server ODBC driver found. Install one, or set DB_ODBC_DRIVER "
-            f"in env/TEST.env. Available: {pyodbc.drivers()}",
-            file=sys.stderr,
+            f"in env/TEST.env. Available: {pyodbc.drivers()}"
         )
-        return 1
 
     # Driver 17/18 understand (and 18 defaults to requiring) TLS, and reject a
     # self-signed server cert unless told to trust it. The legacy "SQL Server"
@@ -189,15 +199,40 @@ def main() -> int:
     tls = "Encrypt=yes;TrustServerCertificate=yes;" if driver.startswith("ODBC Driver") else ""
     conn_str = f"DRIVER={{{driver}}};SERVER={server};DATABASE={db};UID={uid};PWD={pwd};{tls}"
     print(f"Using ODBC driver: {driver}")
-    conn = pyodbc.connect(conn_str, autocommit=True)
+    return pyodbc.connect(conn_str, autocommit=True)
+
+
+def main() -> int:
+    for path in (SCHEMA_SQL, SEED_SQL):
+        if not path.exists():
+            print(f"Missing: {path}", file=sys.stderr)
+            return 1
+
     try:
-        cursor = conn.cursor()
-        tables, progs = wipe_database(cursor)
-        print(f"Wiped {db} on {server} ({tables} tables, {progs} views/procs/functions)")
-        print(f"Applying schema to {db} on {server}...")
-        execute_sql_file(cursor, SCHEMA_SQL)
-        print(f"Applying seed to {db} on {server}...")
-        execute_sql_file(cursor, SEED_SQL)
+        conn = connect_test_db()
+    except TestDbUnavailableError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+    except pyodbc.Error as e:
+        print(f"Could not connect to NEXORA_TEST: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        # Wiping and re-seeding while someone else's suite is mid-run is exactly
+        # what #235 is about, so queue behind them rather than pull dbo.Users out
+        # from under a running test.
+        with db_lock.hold(conn, label="test_db_reset"):
+            cursor = conn.cursor()
+            server = cursor.execute("SELECT @@SERVERNAME").fetchval()
+            tables, progs = wipe_database(cursor)
+            print(f"Wiped NEXORA_TEST on {server} ({tables} tables, {progs} views/procs/functions)")
+            print(f"Applying schema to NEXORA_TEST on {server}...")
+            execute_sql_file(cursor, SCHEMA_SQL)
+            print(f"Applying seed to NEXORA_TEST on {server}...")
+            execute_sql_file(cursor, SEED_SQL)
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        return 1
     finally:
         conn.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ nx_lib.config would load whatever environment is currently active.
 """
 
 import os
+import sys
 
 # CRITICAL: set BEFORE importing nx_lib. setdefault avoids overwriting if a
 # caller deliberately set a different environment (e.g. for debug).
@@ -29,6 +30,52 @@ TOTP_SECRETS = {
 }
 
 TEST_PASSWORD = "Test1234!"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _shared_test_db_lock(request):
+    """Serialise this whole pytest session against other runs (#235).
+
+    One NEXORA_TEST is shared by CI and every local run, and both sides reset
+    it. Holding the lock for the session -- not just the reset -- is the point:
+    the collisions that cost a day were a peer's reset landing in the middle of
+    a suite, not two resets racing.
+
+    Fails OPEN when the database is unreachable. A run that cannot connect
+    cannot corrupt anyone, and pure-unit runs should not start needing a
+    server. Anything that genuinely needs the DB fails later on its own terms.
+    """
+    try:
+        from scripts.db_lock import hold
+        from scripts.test_db_reset import connect_test_db
+    except ImportError as e:  # pragma: no cover - repo layout changed
+        print(f"[db-lock] helper unavailable, not serialising: {e}", file=sys.stderr)
+        yield
+        return
+
+    try:
+        conn = connect_test_db()
+    except Exception as e:
+        print(f"[db-lock] no NEXORA_TEST connection, not serialising: {e}", file=sys.stderr)
+        yield
+        return
+
+    # pytest captures stderr, so hold()'s "waiting for a peer" line would never
+    # reach the terminal and a 20-minute wait would look like a freeze.
+    capman = request.config.pluginmanager.getplugin("capturemanager")
+
+    def notify(msg):
+        if capman is None:
+            print(msg, file=sys.stderr, flush=True)
+            return
+        with capman.global_and_fixture_disabled():
+            print(msg, file=sys.stderr, flush=True)
+
+    try:
+        with hold(conn, label="pytest", notify=notify):
+            yield
+    finally:
+        conn.close()
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/test_db_lock.py
+++ b/tests/unit/test_db_lock.py
@@ -1,0 +1,80 @@
+"""The shared-database lock must actually exclude a second holder (#235).
+
+Uses a throwaway resource name per test, not the real `nexora_test_suite` --
+the session fixture in conftest.py is already holding that one, so contending
+on it would deadlock against ourselves.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from scripts.db_lock import RESOURCE, SKIP_ENV, hold
+
+pytestmark = pytest.mark.usefixtures()
+
+
+def _conn():
+    """Second, independent SQL session -- the lock is per-session, so a single
+    connection could re-acquire its own lock and prove nothing."""
+    try:
+        from scripts.test_db_reset import connect_test_db
+
+        return connect_test_db()
+    except Exception as e:
+        pytest.skip(f"NEXORA_TEST unreachable: {e}")
+
+
+def test_second_holder_is_refused_while_first_holds():
+    resource = f"nexora_test_lock_probe_{uuid.uuid4().hex[:12]}"
+    first, second = _conn(), _conn()
+    try:
+        # Entered left to right: first takes the lock, then the second ask for
+        # the same resource must be refused. timeout_ms=0 makes that immediate.
+        with (
+            hold(first, label="first", resource=resource, timeout_ms=0),
+            pytest.raises(RuntimeError, match="could not acquire"),
+            hold(second, label="second", resource=resource, timeout_ms=0),
+        ):
+            pytest.fail("second holder acquired a lock the first was holding")
+    finally:
+        first.close()
+        second.close()
+
+
+def test_lock_is_released_when_the_block_exits():
+    resource = f"nexora_test_lock_probe_{uuid.uuid4().hex[:12]}"
+    first, second = _conn(), _conn()
+    try:
+        with hold(first, label="first", resource=resource, timeout_ms=0):
+            pass
+        # Released, so an unrelated session takes it without waiting.
+        with hold(second, label="second", resource=resource, timeout_ms=0) as state:
+            assert state != "skipped"
+    finally:
+        first.close()
+        second.close()
+
+
+def test_skip_env_bypasses_locking(monkeypatch):
+    """The escape hatch must not touch the database at all -- it is what you
+    reach for when the lock itself is the problem."""
+    monkeypatch.setenv(SKIP_ENV, "1")
+
+    class Exploding:
+        def cursor(self):
+            raise AssertionError("skip must not open a cursor")
+
+    with hold(Exploding(), label="skipped", resource=RESOURCE) as state:
+        assert state == "skipped"
+
+
+def test_real_resource_name_is_stable():
+    """CI, the reset script and the suite must contend on the same string;
+    a rename that reaches only one of them silently stops serialising."""
+    assert RESOURCE == "nexora_test_suite"
+    assert SKIP_ENV == "NEXORA_TEST_LOCK_SKIP"
+    assert os.environ.get(SKIP_ENV) != "1", "unset NEXORA_TEST_LOCK_SKIP to run this suite"

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -25,7 +25,10 @@ IMPORT_TO_DIST = {
     "psycopg2": "psycopg2-binary",
 }
 
-FIRST_PARTY = {"nx_lib", "nx_main", "tests", "conftest"}
+# "scripts" joined the list when scripts/test_db_reset.py started importing
+# scripts/db_lock.py -- it is a directory in this repo, not a PyPI package,
+# so it can never appear in pyproject.toml.
+FIRST_PARTY = {"nx_lib", "nx_main", "tests", "conftest", "scripts"}
 
 
 def _normalize(name: str) -> str:


### PR DESCRIPTION
Implements option 2 from #235.

There is exactly one `NEXORA_TEST`, on `INTSQL01`, shared by CI and every local run, with nothing serialising access. Both the pre-push gate and CI's `test` job begin by resetting it, so whichever starts second re-seeds `dbo.Users` under the one already running.

## Why it was worth fixing rather than living with

The symptom never points at the cause. One random test out of ~2110 fails, never the same one twice, always passing in isolation:

- `KeyError: 'userid'` in a generali reporting fixture
- `/login failed for admin@test.local: status=401`
- `test_filter_views_crud_roundtrip`
- `test_free_form_sql_fragment_columns_are_never_written`
- `test_api_admin_permission_users_seeded`

Every one reads as "that test is flaky". In one day it caused **five failed CI runs**, blocked #233 and #234 (both entirely correct), and reddened #231's deploy *after* it had already merged, leaving `main` red and that PR's code un-deployed.

## What this does

Both `scripts/test_db_reset.py` and the pytest session take an exclusive `sp_getapplock` on `nexora_test_suite`. The second run waits instead of trampling:

```
[db-lock] another test run holds nexora_test_suite; waiting up to 20 min (pytest).
[db-lock] acquired after 11s
```

`@LockOwner='Session'` ties the lock to the SQL session holding it, so a killed run frees it when SQL Server reaps that session — there is no stale lock to clear by hand.

Locking the *whole pytest session*, not just the reset, is the point: the collisions that cost the day were a peer's reset landing in the middle of a suite, not two resets racing.

| Variable | Effect |
|---|---|
| `NEXORA_TEST_LOCK_SKIP=1` | Don't lock. Mirrors the `SQL_SYNC_SKIP=1` convention. |
| `NEXORA_TEST_LOCK_TIMEOUT_MS` | Override the 20-minute wait. |

A run that cannot reach the database doesn't lock at all — it cannot corrupt anyone, and pure-unit runs keep working offline rather than newly requiring a server.

## Verified

With a peer holding the lock, a second pytest session queued and said why, instead of running concurrently:

```
[db-lock] another test run holds nexora_test_suite; waiting up to 20 min (pytest).
[db-lock] acquired after 11s
4 passed in 11.02s
```

The same run without a holder finishes in 0.47s. `tests/unit/test_db_lock.py` covers exclusion, release, the skip hatch, and that the resource name stays stable — a rename reaching only one caller would silently stop serialising.

## Two notes for review

`conftest` suspends pytest's output capture for that notice. Without it the line is swallowed and a 20-minute wait looks like a freeze, which is how you get someone killing the run and re-creating the collision.

`test_dependencies.py` gains `scripts` in `FIRST_PARTY`: `scripts/test_db_reset.py` now imports `scripts/db_lock.py`, and `scripts` is a directory in this repo, so it can never appear in `pyproject.toml`.

Elapsed time is **not** a reliable tell for contention — #231's deploy failed in 3m54s, inside the normal ~5m. A brief collision reddens a run without slowing it. That is why this is a lock and not a documented "check before you run".

Closes #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPcHu5FRCmxX4vR98vs1yo
