### PR TITLE
fix(generali): average over days in range, not days with data (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,20 @@ Work toward the next release.
 
 ### Fixed
 
+- **The Generali dashboard's daily average no longer rewards missing data.**
+  `api_generali_stats` built the trend x-axis -- and the average's
+  denominator -- from the rows the trend query returned, so days with no
+  rows did not exist. July 2026 is missing 11 days (04.07.-14.07.), so its
+  119'670 documents were divided by 20 instead of 31: 5'983.5/day, *higher*
+  than complete June's 5'715.9 despite 30% fewer documents, with the arrow
+  contradicting the total right beside it. The worse a month's coverage, the
+  better it scored. Both now run over every calendar day in the selected
+  range (`days_in_range()`), so the average reads 3'860.3 and falls with the
+  total, and the chart plots empty days as zero instead of drawing 03.07
+  adjacent to 15.07 and hiding the outage. The response also carries
+  `days_in_range` / `days_with_data` so the UI can qualify the figure
+  (#249).
+
 - **A flaky auth test no longer reddens CI at random.**
   `_without_csrf_token()` in `tests/integration/test_auth_routes.py` blanked
   the CSRF token in the `<meta>` tag but not the one in the form's hidden

--- a/nx_lib/views/generali/documents.py
+++ b/nx_lib/views/generali/documents.py
@@ -1,11 +1,35 @@
 """Generali tenant: Evaluation/Documents (dashboard, document list, stats API)."""
 
 import math
+from datetime import date, timedelta
 
 from flask import current_app, jsonify, redirect, render_template, request, session, url_for
 from flask_babel import gettext as _
 
 from ...security import page_visibility, require_permission
+
+
+def days_in_range(start_date, end_date):
+    """Every calendar day in ``[start_date, end_date]`` as ``YYYY-MM-DD`` strings.
+
+    The dashboard's daily average and its trend x-axis both have to run over
+    the days the user *selected*, not the days that happened to return rows --
+    see ``api_generali_stats``. Accepts either bound with or without a time
+    part (``2026-07-01`` / ``2026-07-01 00:00:00``).
+
+    Returns ``[]`` for an unparsable bound or an inverted range, so callers
+    fall back to the observed days instead of crashing on a shape we did not
+    anticipate.
+    """
+    try:
+        start = date.fromisoformat(str(start_date)[:10])
+        end = date.fromisoformat(str(end_date)[:10])
+    except (TypeError, ValueError):
+        return []
+    if end < start:
+        return []
+    return [(start + timedelta(days=i)).isoformat() for i in range((end - start).days + 1)]
+
 
 # ----------------------------- Generali Evaluation -------------------------- #
 
@@ -113,12 +137,25 @@ def api_generali_stats():
         )
         trend_rows = cursor.fetchall()
 
-        labels = sorted({str(r[0]) for r in trend_rows})
+        observed = {str(r[0]) for r in trend_rows}
+        # Every day in the selected range, including the ones with no rows.
+        # Deriving the axis from the result set instead produced two bugs
+        # (#249): a month missing 11 days was divided by 20 and so scored a
+        # HIGHER daily average than a complete month -- the worse the
+        # coverage, the better the KPI looked -- and the chart drew 03.07
+        # adjacent to 15.07 as though they were consecutive, hiding the gap.
+        # Falls back to the observed days if the bounds will not parse.
+        labels = days_in_range(start_date, end_date) or sorted(observed)
         label_index = {d: i for i, d in enumerate(labels)}
         totals = [0] * len(labels)
         by_komm = {}
         for d, k, c in trend_rows:
-            i = label_index[str(d)]
+            # A row outside the parsed range is dropped rather than raising:
+            # labels no longer come from these rows, so membership is not
+            # guaranteed the way it was when the axis was built from them.
+            i = label_index.get(str(d))
+            if i is None:
+                continue
             totals[i] += c
             if k not in by_komm:
                 by_komm[k] = [0] * len(labels)
@@ -127,6 +164,10 @@ def api_generali_stats():
         trend_data = {"labels": labels, "values": totals, "byKommunikation": by_komm}
 
         kpis["avg_daily"] = round(total / len(labels), 1) if total > 0 and labels else 0
+        # Coverage of the selected range, so the UI can qualify the average
+        # rather than presenting a gap-inflated number as comparable.
+        kpis["days_in_range"] = len(labels)
+        kpis["days_with_data"] = len(observed.intersection(labels))
 
         cursor.execute(
             f"""

--- a/tests/integration/test_generali_stats_coverage.py
+++ b/tests/integration/test_generali_stats_coverage.py
@@ -1,0 +1,172 @@
+"""Integration tests for the Generali stats endpoint's day coverage (#249).
+
+`api_generali_stats` used to derive the trend x-axis -- and the daily-average
+denominator -- from the rows the trend query returned, so days with no rows
+simply did not exist. Two consequences, both reproduced below:
+
+  * the average was divided by days-with-data instead of days-in-range, so a
+    range missing a third of its days scored a HIGHER daily average than a
+    complete one;
+  * the chart plotted the surviving days adjacently, drawing 03.07 next to
+    15.07 as if they were consecutive and hiding an 11-day outage.
+
+Permissions are patched at nx_lib.hooks.load_permissions_for_user because a
+before_request hook reloads them from the DB on every request -- same seam as
+tests/integration/test_generali_stats_routes.py.
+
+The engine is faked at the package attribute (nx_lib.views.generali), which is
+what the endpoint's local `from . import engine_generali_db` re-resolves.
+"""
+
+from datetime import date
+
+import nx_lib.hooks as hooks
+import nx_lib.views.generali as gv
+
+
+def _grant_perms(monkeypatch, perms):
+    monkeypatch.setattr(hooks, "load_permissions_for_user", lambda uid: list(perms))
+
+
+class _FakeStatsCursor:
+    """Answers the query shapes api_generali_stats issues, in order.
+
+    Only the KPI aggregate and the daily trend carry data; every other
+    breakdown returns no rows, which the endpoint renders as empty chart
+    dicts.
+    """
+
+    def __init__(self, kpi_row, trend_rows):
+        self._kpi_row = kpi_row
+        self._trend_rows = trend_rows
+        self._result = []
+
+    def execute(self, sql, params=None):
+        normalized = " ".join(sql.split())
+        if "as TotalDocs" in normalized:
+            self._result = [self._kpi_row]
+        elif "GROUP BY CAST(DOC_SCANDATUM AS DATE)" in normalized:
+            self._result = list(self._trend_rows)
+        else:
+            self._result = []
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return self._result
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        pass
+
+
+class _FakeEngine:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def raw_connection(self):
+        return self._conn
+
+
+def _wire(monkeypatch, kpi_row, trend_rows):
+    cursor = _FakeStatsCursor(kpi_row, trend_rows)
+    monkeypatch.setattr(gv, "engine_generali_db", _FakeEngine(_FakeConn(cursor)))
+
+
+def _get(client, start="2026-07-01", end="2026-07-10"):
+    resp = client.get(f"/api/generali/stats?startDate={start}T00:00:00&endDate={end}T23:59:59")
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    body = resp.get_json()
+    assert body["success"] is True
+    return body
+
+
+# 300 docs over a 10-day range, but only two of those days produced rows.
+_KPI_ROW = (300, 225, 195, 165)
+_TREND_ROWS = [
+    (date(2026, 7, 1), "Brief", 100),
+    (date(2026, 7, 2), "Brief", 200),
+]
+
+
+def test_average_divides_by_days_in_range_not_days_with_data(user_client, monkeypatch):
+    _grant_perms(monkeypatch, ["generali.dashboard.view"])
+    _wire(monkeypatch, _KPI_ROW, _TREND_ROWS)
+
+    kpis = _get(user_client)["kpis"]
+
+    # 300 / 10 calendar days. The bug divided by the 2 days that had rows
+    # and reported 150.0 -- five times too high.
+    assert kpis["avg_daily"] == 30.0
+
+
+def test_coverage_is_reported_alongside_the_average(user_client, monkeypatch):
+    _grant_perms(monkeypatch, ["generali.dashboard.view"])
+    _wire(monkeypatch, _KPI_ROW, _TREND_ROWS)
+
+    kpis = _get(user_client)["kpis"]
+
+    assert kpis["days_in_range"] == 10
+    assert kpis["days_with_data"] == 2
+
+
+def test_trend_axis_keeps_the_empty_days(user_client, monkeypatch):
+    _grant_perms(monkeypatch, ["generali.dashboard.view"])
+    _wire(monkeypatch, _KPI_ROW, _TREND_ROWS)
+
+    trend = _get(user_client)["trend"]
+
+    assert len(trend["labels"]) == 10
+    assert trend["labels"][0] == "2026-07-01"
+    assert trend["labels"][-1] == "2026-07-10"
+    # the gap is present and zero, not absent
+    assert "2026-07-05" in trend["labels"]
+    assert trend["values"] == [100, 200, 0, 0, 0, 0, 0, 0, 0, 0]
+
+
+def test_per_kommunikation_series_is_padded_to_the_same_length(user_client, monkeypatch):
+    _grant_perms(monkeypatch, ["generali.dashboard.view"])
+    _wire(monkeypatch, _KPI_ROW, _TREND_ROWS)
+
+    trend = _get(user_client)["trend"]
+
+    # a series shorter than labels would silently misalign in Chart.js
+    for series in trend["byKommunikation"].values():
+        assert len(series) == len(trend["labels"])
+    assert trend["byKommunikation"]["Brief"] == [100, 200, 0, 0, 0, 0, 0, 0, 0, 0]
+
+
+def test_complete_range_is_unchanged_by_the_fix(user_client, monkeypatch):
+    _grant_perms(monkeypatch, ["generali.dashboard.view"])
+    rows = [(date(2026, 7, d), "Brief", 10) for d in range(1, 11)]
+    _wire(monkeypatch, (100, 75, 65, 55), rows)
+
+    body = _get(user_client)
+
+    assert body["kpis"]["avg_daily"] == 10.0
+    assert body["kpis"]["days_with_data"] == body["kpis"]["days_in_range"] == 10
+    assert body["trend"]["values"] == [10] * 10
+
+
+def test_rows_outside_the_range_are_dropped_not_fatal(user_client, monkeypatch):
+    """Labels no longer come from the rows, so membership is not guaranteed."""
+    _grant_perms(monkeypatch, ["generali.dashboard.view"])
+    rows = [*_TREND_ROWS, (date(2026, 8, 1), "Brief", 999)]
+    _wire(monkeypatch, _KPI_ROW, rows)
+
+    body = _get(user_client)
+
+    assert len(body["trend"]["labels"]) == 10
+    assert "2026-08-01" not in body["trend"]["labels"]
+    assert sum(body["trend"]["values"]) == 300

--- a/tests/unit/test_generali_days_in_range.py
+++ b/tests/unit/test_generali_days_in_range.py
@@ -1,0 +1,63 @@
+"""Unit tests for nx_lib.views.generali.documents.days_in_range.
+
+The dashboard's daily average and its trend x-axis both run over this list.
+Before #249 both were derived from the query result instead, so a range with
+missing days was divided by a smaller denominator and scored a *higher*
+average than a complete one.
+"""
+
+from nx_lib.views.generali.documents import days_in_range
+
+
+def test_single_day_range_is_one_label():
+    assert days_in_range("2026-07-05", "2026-07-05") == ["2026-07-05"]
+
+
+def test_range_includes_both_bounds():
+    assert days_in_range("2026-07-01", "2026-07-04") == [
+        "2026-07-01",
+        "2026-07-02",
+        "2026-07-03",
+        "2026-07-04",
+    ]
+
+
+def test_full_month_yields_every_calendar_day():
+    days = days_in_range("2026-07-01", "2026-07-31")
+    assert len(days) == 31
+    # the 11-day hole that exposed the bug is present, not skipped
+    assert "2026-07-04" in days
+    assert "2026-07-14" in days
+
+
+def test_time_part_is_ignored():
+    # the endpoint hands over "2026-07-01 00:00:00" after replacing the T
+    assert days_in_range("2026-07-01 00:00:00", "2026-07-03 23:59:59") == [
+        "2026-07-01",
+        "2026-07-02",
+        "2026-07-03",
+    ]
+
+
+def test_range_spanning_a_month_boundary():
+    assert days_in_range("2026-06-29", "2026-07-02") == [
+        "2026-06-29",
+        "2026-06-30",
+        "2026-07-01",
+        "2026-07-02",
+    ]
+
+
+def test_leap_day_is_included():
+    assert "2028-02-29" in days_in_range("2028-02-27", "2028-03-01")
+
+
+def test_inverted_range_yields_nothing():
+    assert days_in_range("2026-07-31", "2026-07-01") == []
+
+
+def test_unparsable_bounds_yield_nothing():
+    # callers fall back to the observed days rather than crashing
+    assert days_in_range("not-a-date", "2026-07-01") == []
+    assert days_in_range("2026-07-01", "") == []
+    assert days_in_range(None, None) == []


### PR DESCRIPTION
Closes #249 (defects 1 and 3; defect 2 is a product decision — see below).

## The bug

`api_generali_stats` derived the trend x-axis — and the daily average's denominator — from the rows the trend query returned, so a day with no rows simply did not exist.

July 2026 is missing 11 consecutive days (04.07.–14.07.), so its 119'670 documents were divided by **20** rather than 31:

| | Total | Days used as denominator | Avg shown |
|---|---|---|---|
| June 2026 (complete) | 171,477 | 30 | 5,715.9 |
| July 2026 (11 days missing) | 119,670 | **20** | **5,983.5** |

July scored a *higher* daily average than June despite 30% fewer documents — the average rose while the total beside it fell, and the two arrows on the dashboard contradicted each other. The worse a month's coverage, the better it scored, and the figure was not comparable between two periods with different coverage.

The same variable fed the chart, which drew `03.07` adjacent to `15.07` as though they were consecutive — an 11-day outage rendered as a continuous line.

## The fix

Both now run over every calendar day in the selected range, via a pure `days_in_range()` helper that falls back to the observed days if a bound will not parse. July reads **3,860.3** and falls 32.5% against June, agreeing with the total. Empty days plot as zero, so a gap is visible instead of compressed away.

Rows outside the parsed range are dropped rather than raising — labels no longer come from those rows, so membership is not guaranteed the way it was when the axis was built from them.

The response also carries `days_in_range` / `days_with_data` so the UI can qualify the average rather than presenting a gap-inflated number as comparable.

## Verification

Stashed the fix and re-ran the new tests against the old code — they fail with `assert 150.0 == 30.0` (300 documents ÷ the 2 days that had rows), labels of length 2 instead of 10, and unpadded per-`Kommunikation` series that would silently misalign in Chart.js.

17 new tests. Full fast tier: **2244 passed / 37 skipped / 0 failed.**

- `tests/unit/test_generali_days_in_range.py` — the pure helper: bounds, time parts, month boundaries, leap day, inverted and unparsable ranges
- `tests/integration/test_generali_stats_coverage.py` — the endpoint, via the fake-cursor seam from `test_generali_pdqm_routes.py`

## Three things worth a reviewer's attention

**The denominator is calendar days.** #249 left this open (calendar vs working days). Calendar days is what makes the average agree with the total; if the business reads this as throughput-per-*working*-day, that is a different number and a one-line change.

**The view is untouched.** `WHERE ifl.Value = 'CaptivaCapture'` in `v_ReportJobJoinDefinitions` is *why* those 11 days are absent — 189,038 rows exist in `dbo.ReportJob` for those dates, none of them Captiva. Changing that clause changes what the entire Generali dashboard counts, which is a product decision, not a bug fix. Still open on the issue.

**`days_in_range` / `days_with_data` have no consumer yet.** Adding the coverage line to the KPI card needs new user-facing strings and therefore a de/fr/it translation cycle; left as a follow-up rather than bundled here.

## Deploy note

No migration, no template change, so nothing needs an env key or a schema step. It *is* a real runtime change to `nx_lib/`, so it earns its ~34s app-pool restart — worth timing for a quiet window.

Payload tradeoff: zero-filling makes the trend payload proportional to the selected range rather than to the data. A normal month is ~31 points; a ten-year range would be ~3,650 instead of however many days had rows.
