### PR TITLE
fix(git): pin the remaining text types to LF (#287)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -33,6 +33,36 @@ scripts/git-hooks/*   text eol=lf
 .mcp.json             text eol=lf
 .claude/settings.json text eol=lf
 
+# Everything else that is text. Same story as the three blocks above, and the
+# reason this list keeps growing: `* text=auto` checks a file out as CRLF on
+# Windows, the mixed-line-ending hook rewrites it to LF, and the pre-push
+# full-range scan then rejects the whole push -- on `main`'s own content, for
+# anybody. Measured on 2026-09-08: 108 files, so no push could succeed at all.
+#
+# Pinning by type rather than excluding the paths from the hook, because most of
+# these are real source (21 files under static/css/) rather than vendored output
+# like sql/. The design_handoff trees are generated, but they are checked in and
+# read by people, so LF is right for them too.
+*.css                 text eol=lf
+*.jsx                 text eol=lf
+*.ts                  text eol=lf
+*.cjs                 text eol=lf
+*.json                text eol=lf
+*.txt                 text eol=lf
+*.toml                text eol=lf
+*.cfg                 text eol=lf
+*.lock                text eol=lf
+*.drawio              text eol=lf
+*.env.example         text eol=lf
+# Extensionless and dotfiles, which no glob above reaches.
+LICENSE               text eol=lf
+.gitignore            text eol=lf
+.gitattributes        text eol=lf
+.editorconfig         text eol=lf
+.gitlint              text eol=lf
+.claudeignore         text eol=lf
+.python-version       text eol=lf
+
 # Task Scheduler task definitions. The Task Scheduler engine only accepts
 # UTF-16 XML (handing it UTF-8 fails with "unable to switch the encoding"), and
 # UTF-16 is half NUL bytes — any line-ending or end-of-file normalization


### PR DESCRIPTION
Closes #287 (the line-ending half).

The `mixed-line-ending` pre-commit hook was failing on `main`'s own content. Measured against a clean checkout of `origin/main`: **108 files "fixed"**, so the hook modified the tree and the pre-push scan rejected the push — for anybody, on any branch, regardless of what was being pushed. That's most of why four pushes failed today.

## This file already knew the answer

`.gitattributes` carries this exact fix three times, once per type that bit someone:

```
*.html *.js            "the mixed-line-ending hook enforces LF, but autocrlf checks them
                        out as CRLF on Windows, so a push's full-range scan rejects them"
*.md *.po *.pot        same comment
.mcp.json, settings    same comment
```

This adds the types that hadn't hit it yet: the CSS (**21 files under `static/css/`**), the `design_handoff` trees #279 brought in, and the root config that was quietly in the same state — `LICENSE`, `.gitignore`, `requirements*.txt`, `pyproject.toml`, `uv.lock`, `env/*.env.example`, and the dotfiles no glob reached.

## Two decisions worth reviewing

**Pinned by type, not excluded from the hook** — unlike `sql/`, which is excluded because mssql-scripter regenerates it. Most of these are real source, and the `design_handoff` trees are checked in to be read by people even though a tool emits them.

**No mass renormalisation commit.** The blobs were already LF, since `* text=auto` normalises on add — only the *checkout* conversion was wrong. So 30 lines of attributes fix it and no 108-file churn commit is needed. Verified with `git diff --cached --ignore-cr-at-eol`, which reports zero changes beyond this file.

## Verified

`mixed-line-ending`, `check-yaml` and `detect-private-key` all pass `--all-files` afterwards, and the hook is idempotent on a second run. The push of this branch was the first fully green pre-push gate of the day, and the three branches that had been failing on this hook pushed successfully once they merged it.
