### PR TITLE
fix(sql): 0125 degrades gracefully when a client table is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and nothing bleeds in beside it; the editor preview re-runs on every change.
 
 ### Fixed
+- Migration 0125 (field-quality view) built with the same table-aware dynamic SQL as 0110/0111, so a PROD server without the INT-only Bucherer telemetry table no longer fails the deploy's migration step.
 - **Definition chart tiles said "Not available"** for decimal measures (hours,
   amounts): the run API serialises them as strings, which the tile renderer
   rejected. Numeric strings now count, and a report with two breakdowns pivots

--- a/sql/NexoraDB/Views/dbo.vFieldExtractionQuality.sql
+++ b/sql/NexoraDB/Views/dbo.vFieldExtractionQuality.sql
@@ -4,74 +4,12 @@ DROP VIEW [dbo].[vFieldExtractionQuality]
 GO
 SET ANSI_NULLS ON
 GO
-SET QUOTED_IDENTIFIER ON
+SET QUOTED_IDENTIFIER OFF
 GO
+
 CREATE   VIEW [dbo].[vFieldExtractionQuality] AS
-WITH cfa AS (
-    SELECT N'Bucherer' AS Customer, N'bucherer' AS Stream, NULL AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [SYDOC_Statistik].dbo.Bucherer_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Compass' AS Customer, N'compass' AS Stream, N'CMPS' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [SYDOC_Statistik].dbo.Compass_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'ElektroMaterial' AS Customer, N'em' AS Stream, N'LKTR' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [SYDOC_Statistik].dbo.Em_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Geberit' AS Customer, N'geberit' AS Stream, NULL AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [SYDOC_Statistik].dbo.Geberit_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Privera' AS Customer, N'priverainvoice' AS Stream, N'PRVR' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [SYDOC_Statistik].dbo.PriveraInvoice_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Privera' AS Customer, N'priverainvoice2025' AS Stream, N'PRVR' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [SYDOC_Statistik].dbo.PriveraInvoice2025_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Privera' AS Customer, N'priverapost' AS Stream, N'PRVR' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [SYDOC_Statistik].dbo.PriveraPost_Collect_Field_Attributes
-),
-dates AS (
-    SELECT N'bucherer' AS Stream, CONVERT(nvarchar(50), [Workitem]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate
-    FROM [SYDOC_Statistik].dbo.Bucherer_Invoice
-    GROUP BY CONVERT(nvarchar(50), [Workitem]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'compass' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate
-    FROM [SYDOC_Statistik].dbo.Compass_Invoice
-    GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'em' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDatetime]) AS ImportDate, MAX([ExportEM_dt]) AS ExportDate
-    FROM [SYDOC_Statistik].dbo.EM_Invoice
-    GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'geberit' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate
-    FROM [SYDOC_Statistik].dbo.Geberit_Garantiekarten
-    GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'priverainvoice' AS Stream, CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportTime]) AS ImportDate, MAX([ExportDate]) AS ExportDate
-    FROM [SYDOC_Statistik].dbo.PriveraInvoice
-    GROUP BY CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'priverainvoice2025' AS Stream, CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportTime]) AS ImportDate, MAX([ExportDate]) AS ExportDate
-    FROM [SYDOC_Statistik].dbo.PriveraInvoice
-    GROUP BY CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'priverapost' AS Stream, CONVERT(nvarchar(50), [WorkItemID]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDatetime_dt]) AS ImportDate, MAX([ExportDatetime_dt]) AS ExportDate
-    FROM [SYDOC_Statistik].dbo.PriveraPosteingang
-    GROUP BY CONVERT(nvarchar(50), [WorkItemID]) COLLATE DATABASE_DEFAULT
-)
+WITH cfa AS (SELECT N'Bucherer' AS Customer, N'bucherer' AS Stream, NULL AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [SYDOC_Statistik].dbo.Bucherer_Collect_Field_Attributes UNION ALL SELECT N'Compass' AS Customer, N'compass' AS Stream, N'CMPS' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [SYDOC_Statistik].dbo.Compass_Collect_Field_Attributes UNION ALL SELECT N'ElektroMaterial' AS Customer, N'em' AS Stream, N'LKTR' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [SYDOC_Statistik].dbo.Em_Collect_Field_Attributes UNION ALL SELECT N'Geberit' AS Customer, N'geberit' AS Stream, NULL AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [SYDOC_Statistik].dbo.Geberit_Collect_Field_Attributes UNION ALL SELECT N'Privera' AS Customer, N'priverainvoice' AS Stream, N'PRVR' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [SYDOC_Statistik].dbo.PriveraInvoice_Collect_Field_Attributes UNION ALL SELECT N'Privera' AS Customer, N'priverainvoice2025' AS Stream, N'PRVR' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [SYDOC_Statistik].dbo.PriveraInvoice2025_Collect_Field_Attributes UNION ALL SELECT N'Privera' AS Customer, N'priverapost' AS Stream, N'PRVR' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [SYDOC_Statistik].dbo.PriveraPost_Collect_Field_Attributes),
+dates AS (SELECT N'bucherer' AS Stream, CONVERT(nvarchar(50), [Workitem]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate FROM [SYDOC_Statistik].dbo.Bucherer_Invoice GROUP BY CONVERT(nvarchar(50), [Workitem]) COLLATE DATABASE_DEFAULT UNION ALL SELECT N'compass' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate FROM [SYDOC_Statistik].dbo.Compass_Invoice GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT UNION ALL SELECT N'em' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDatetime]) AS ImportDate, MAX([ExportEM_dt]) AS ExportDate FROM [SYDOC_Statistik].dbo.EM_Invoice GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT UNION ALL SELECT N'geberit' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate FROM [SYDOC_Statistik].dbo.Geberit_Garantiekarten GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT UNION ALL SELECT N'priverainvoice' AS Stream, CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportTime]) AS ImportDate, MAX([ExportDate]) AS ExportDate FROM [SYDOC_Statistik].dbo.PriveraInvoice GROUP BY CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT UNION ALL SELECT N'priverainvoice2025' AS Stream, CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportTime]) AS ImportDate, MAX([ExportDate]) AS ExportDate FROM [SYDOC_Statistik].dbo.PriveraInvoice GROUP BY CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT UNION ALL SELECT N'priverapost' AS Stream, CONVERT(nvarchar(50), [WorkItemID]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDatetime_dt]) AS ImportDate, MAX([ExportDatetime_dt]) AS ExportDate FROM [SYDOC_Statistik].dbo.PriveraPosteingang GROUP BY CONVERT(nvarchar(50), [WorkItemID]) COLLATE DATABASE_DEFAULT)
 SELECT
     cfa.Customer                                      AS Customer,
     cfa.Stream                                        AS Stream,
@@ -84,13 +22,9 @@ SELECT
     cfa.[TYPE]                                        AS FieldType,
     d.ImportDate                                      AS ImportDate,
     d.ExportDate                                      AS ExportDate,
-    -- Octo stores confidences as 0..1 strings; x100 makes them percentages.
     TRY_CONVERT(float, cfa.CONF_BEST_CANDIDATE) * 100 AS Confidence,
     TRY_CONVERT(float, cfa.CONF_2ND_CANDIDATE)  * 100 AS Confidence2nd,
     TRY_CONVERT(float, cfa.[TIME])                    AS ExtractionTimeMs,
-    -- 0/100 FLOATS, not 0/1 ints: the reporting layer emits a bare AVG(col) and
-    -- T-SQL integer-divides AVG over an int column. As floats, AVG() *is* the
-    -- percentage, with no post-maths.
     CASE WHEN cfa.VALUE_BEFORE_VALIDATION <> '' THEN 100e0 ELSE 0e0 END
                                                       AS ExtractedPct,
     CASE WHEN cfa.VALUE_BEFORE_VALIDATION <> '' AND cfa.[RESULT] = 'Equal'
@@ -102,10 +36,6 @@ SELECT
     TRY_CONVERT(float, cfa.IS_USER_ENTERED)           * 100 AS UserEnteredPct,
     TRY_CONVERT(float, cfa.IS_USER_MODIFIED)          * 100 AS UserModifiedPct,
     TRY_CONVERT(float, cfa.VALUE_FROM_CANDIDATE_LIST) * 100 AS FromCandidateListPct,
-    -- Octo emits hundreds of distinct "fields" per stream, most of them internal
-    -- bookkeeping. Filtering this to 100 narrows a report to the fields nexora
-    -- actually knows about. Widen it by adding dbo.FieldAliases rows, not by
-    -- editing this view.
     CASE WHEN fa.TargetKey IS NULL THEN 0e0 ELSE 100e0 END
                                                       AS MappedInNexoraPct,
     cfa.VALUE_ORIGIN                                  AS ValueOrigin,
@@ -113,23 +43,12 @@ SELECT
     cfa.STATUS_BEFORE_VALIDATION                      AS StatusBeforeValidation,
     cfa.STATUS_AFTER_VALIDATION                       AS StatusAfterValidation
 FROM cfa
--- The date join is keyed on Stream, never Customer: Privera has three telemetry
--- tables across two header tables, so a workitem id present in both would match
--- twice under a Customer key and silently double those rows.
 LEFT JOIN dates d
        ON d.Stream   = cfa.Stream
       AND d.Workitem = cfa.WORKITEM_ID COLLATE DATABASE_DEFAULT
--- COLLATE DATABASE_DEFAULT: NexoraDB is Latin1_General_CI_AS, the statistics DB
--- SQL_Latin1_General_CP1_CI_AS, and an uncollated cross-database string compare
--- is a hard error, not a warning.
 LEFT JOIN dbo.FieldAliases fa
        ON fa.SourceFieldName = cfa.FIELD COLLATE DATABASE_DEFAULT
 LEFT JOIN dbo.FieldLabels  fl ON fl.FieldKey = LOWER(fa.TargetKey)
--- Onboarded customers, every process (0125). 0111 also matched the process
--- name, which hid ElektroMaterial's legacy 01_Invoice_1 and Privera's
--- PriveraPostFields telemetry from customers who are otherwise fully onboarded.
--- The organization gate stays: Bucherer and Geberit carry no OrgCode and remain
--- out until they get an Organizations row.
 WHERE EXISTS (
         SELECT 1
         FROM dbo.ProcessSources ps

--- a/sql/_migrations/NexoraDB/0125_field_quality_all_processes_of_onboarded_customers.sql
+++ b/sql/_migrations/NexoraDB/0125_field_quality_all_processes_of_onboarded_customers.sql
@@ -7,74 +7,66 @@
 -- onboarded customer reports on all of its field telemetry. Bucherer and
 -- Geberit (no organization) stay out, unchanged. View body otherwise identical
 -- to 0111. Idempotent (CREATE OR ALTER).
+--
+-- Schema-adaptive (edited after applied on INT, checksum re-blessed): the first
+-- PROD deploy failed because SYDOC_Statistik has no Bucherer_Collect_Field_Attributes
+-- there -- the same failure 0110/0111 hit (PR #286), same fix: dynamic SQL that
+-- only unions branches whose backing table exists. Gate is organization-only,
+-- as above; the rest of the body is 0111's.
 
 GO
+DECLARE @cfa TABLE (ord INT IDENTITY, txt NVARCHAR(MAX));
+DECLARE @dates TABLE (ord INT IDENTITY, txt NVARCHAR(MAX));
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.Bucherer_Collect_Field_Attributes') IS NOT NULL
+INSERT INTO @cfa (txt) VALUES (N'SELECT N''Bucherer'' AS Customer, N''bucherer'' AS Stream, NULL AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [$(StatisticsDb)].dbo.Bucherer_Collect_Field_Attributes');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.Compass_Collect_Field_Attributes') IS NOT NULL
+INSERT INTO @cfa (txt) VALUES (N'SELECT N''Compass'' AS Customer, N''compass'' AS Stream, N''CMPS'' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [$(StatisticsDb)].dbo.Compass_Collect_Field_Attributes');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.Em_Collect_Field_Attributes') IS NOT NULL
+INSERT INTO @cfa (txt) VALUES (N'SELECT N''ElektroMaterial'' AS Customer, N''em'' AS Stream, N''LKTR'' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [$(StatisticsDb)].dbo.Em_Collect_Field_Attributes');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.Geberit_Collect_Field_Attributes') IS NOT NULL
+INSERT INTO @cfa (txt) VALUES (N'SELECT N''Geberit'' AS Customer, N''geberit'' AS Stream, NULL AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [$(StatisticsDb)].dbo.Geberit_Collect_Field_Attributes');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.PriveraInvoice_Collect_Field_Attributes') IS NOT NULL
+INSERT INTO @cfa (txt) VALUES (N'SELECT N''Privera'' AS Customer, N''priverainvoice'' AS Stream, N''PRVR'' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [$(StatisticsDb)].dbo.PriveraInvoice_Collect_Field_Attributes');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.PriveraInvoice2025_Collect_Field_Attributes') IS NOT NULL
+INSERT INTO @cfa (txt) VALUES (N'SELECT N''Privera'' AS Customer, N''priverainvoice2025'' AS Stream, N''PRVR'' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [$(StatisticsDb)].dbo.PriveraInvoice2025_Collect_Field_Attributes');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.PriveraPost_Collect_Field_Attributes') IS NOT NULL
+INSERT INTO @cfa (txt) VALUES (N'SELECT N''Privera'' AS Customer, N''priverapost'' AS Stream, N''PRVR'' AS OrgCode, WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION FROM [$(StatisticsDb)].dbo.PriveraPost_Collect_Field_Attributes');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.Bucherer_Invoice') IS NOT NULL
+INSERT INTO @dates (txt) VALUES (N'SELECT N''bucherer'' AS Stream, CONVERT(nvarchar(50), [Workitem]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate FROM [$(StatisticsDb)].dbo.Bucherer_Invoice GROUP BY CONVERT(nvarchar(50), [Workitem]) COLLATE DATABASE_DEFAULT');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.Compass_Invoice') IS NOT NULL
+INSERT INTO @dates (txt) VALUES (N'SELECT N''compass'' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate FROM [$(StatisticsDb)].dbo.Compass_Invoice GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.EM_Invoice') IS NOT NULL
+INSERT INTO @dates (txt) VALUES (N'SELECT N''em'' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDatetime]) AS ImportDate, MAX([ExportEM_dt]) AS ExportDate FROM [$(StatisticsDb)].dbo.EM_Invoice GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.Geberit_Garantiekarten') IS NOT NULL
+INSERT INTO @dates (txt) VALUES (N'SELECT N''geberit'' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate FROM [$(StatisticsDb)].dbo.Geberit_Garantiekarten GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT');
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.PriveraInvoice') IS NOT NULL
+BEGIN
+INSERT INTO @dates (txt) VALUES (N'SELECT N''priverainvoice'' AS Stream, CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportTime]) AS ImportDate, MAX([ExportDate]) AS ExportDate FROM [$(StatisticsDb)].dbo.PriveraInvoice GROUP BY CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT');
+INSERT INTO @dates (txt) VALUES (N'SELECT N''priverainvoice2025'' AS Stream, CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportTime]) AS ImportDate, MAX([ExportDate]) AS ExportDate FROM [$(StatisticsDb)].dbo.PriveraInvoice GROUP BY CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT');
+END
+
+IF OBJECT_ID('[$(StatisticsDb)].dbo.PriveraPosteingang') IS NOT NULL
+INSERT INTO @dates (txt) VALUES (N'SELECT N''priverapost'' AS Stream, CONVERT(nvarchar(50), [WorkItemID]) COLLATE DATABASE_DEFAULT AS Workitem, MIN([ImportDatetime_dt]) AS ImportDate, MAX([ExportDatetime_dt]) AS ExportDate FROM [$(StatisticsDb)].dbo.PriveraPosteingang GROUP BY CONVERT(nvarchar(50), [WorkItemID]) COLLATE DATABASE_DEFAULT');
+
+DECLARE @cfaSql NVARCHAR(MAX) = (SELECT STRING_AGG(txt, N' UNION ALL ') WITHIN GROUP (ORDER BY ord) FROM @cfa);
+DECLARE @datesSql NVARCHAR(MAX) = (SELECT STRING_AGG(txt, N' UNION ALL ') WITHIN GROUP (ORDER BY ord) FROM @dates);
+
+DECLARE @sql NVARCHAR(MAX) = N'
 CREATE OR ALTER VIEW dbo.vFieldExtractionQuality AS
-WITH cfa AS (
-    SELECT N'Bucherer' AS Customer, N'bucherer' AS Stream, NULL AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [$(StatisticsDb)].dbo.Bucherer_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Compass' AS Customer, N'compass' AS Stream, N'CMPS' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [$(StatisticsDb)].dbo.Compass_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'ElektroMaterial' AS Customer, N'em' AS Stream, N'LKTR' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [$(StatisticsDb)].dbo.Em_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Geberit' AS Customer, N'geberit' AS Stream, NULL AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [$(StatisticsDb)].dbo.Geberit_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Privera' AS Customer, N'priverainvoice' AS Stream, N'PRVR' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [$(StatisticsDb)].dbo.PriveraInvoice_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Privera' AS Customer, N'priverainvoice2025' AS Stream, N'PRVR' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [$(StatisticsDb)].dbo.PriveraInvoice2025_Collect_Field_Attributes
-    UNION ALL
-    SELECT N'Privera' AS Customer, N'priverapost' AS Stream, N'PRVR' AS OrgCode,
-           WORKITEM_ID, PROCESS, FIELD, [TYPE], VALUE_BEFORE_VALIDATION, [RESULT], [TIME], CONF_BEST_CANDIDATE, CONF_2ND_CANDIDATE, IS_SET_BY_MACHINE, IS_USER_VERIFIED, IS_USER_ENTERED, IS_USER_MODIFIED, VALUE_FROM_CANDIDATE_LIST, VALUE_ORIGIN, HISTORY_SOURCE, STATUS_BEFORE_VALIDATION, STATUS_AFTER_VALIDATION
-    FROM [$(StatisticsDb)].dbo.PriveraPost_Collect_Field_Attributes
-),
-dates AS (
-    SELECT N'bucherer' AS Stream, CONVERT(nvarchar(50), [Workitem]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate
-    FROM [$(StatisticsDb)].dbo.Bucherer_Invoice
-    GROUP BY CONVERT(nvarchar(50), [Workitem]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'compass' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate
-    FROM [$(StatisticsDb)].dbo.Compass_Invoice
-    GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'em' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDatetime]) AS ImportDate, MAX([ExportEM_dt]) AS ExportDate
-    FROM [$(StatisticsDb)].dbo.EM_Invoice
-    GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'geberit' AS Stream, CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDate]) AS ImportDate, MAX([UploadDatetime]) AS ExportDate
-    FROM [$(StatisticsDb)].dbo.Geberit_Garantiekarten
-    GROUP BY CONVERT(nvarchar(50), [WorkItem]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'priverainvoice' AS Stream, CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportTime]) AS ImportDate, MAX([ExportDate]) AS ExportDate
-    FROM [$(StatisticsDb)].dbo.PriveraInvoice
-    GROUP BY CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'priverainvoice2025' AS Stream, CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportTime]) AS ImportDate, MAX([ExportDate]) AS ExportDate
-    FROM [$(StatisticsDb)].dbo.PriveraInvoice
-    GROUP BY CONVERT(nvarchar(50), [WID]) COLLATE DATABASE_DEFAULT
-    UNION ALL
-    SELECT N'priverapost' AS Stream, CONVERT(nvarchar(50), [WorkItemID]) COLLATE DATABASE_DEFAULT AS Workitem,
-           MIN([ImportDatetime_dt]) AS ImportDate, MAX([ExportDatetime_dt]) AS ExportDate
-    FROM [$(StatisticsDb)].dbo.PriveraPosteingang
-    GROUP BY CONVERT(nvarchar(50), [WorkItemID]) COLLATE DATABASE_DEFAULT
-)
+WITH cfa AS (' + @cfaSql + N'),
+dates AS (' + @datesSql + N')
 SELECT
     cfa.Customer                                      AS Customer,
     cfa.Stream                                        AS Stream,
@@ -87,28 +79,20 @@ SELECT
     cfa.[TYPE]                                        AS FieldType,
     d.ImportDate                                      AS ImportDate,
     d.ExportDate                                      AS ExportDate,
-    -- Octo stores confidences as 0..1 strings; x100 makes them percentages.
     TRY_CONVERT(float, cfa.CONF_BEST_CANDIDATE) * 100 AS Confidence,
     TRY_CONVERT(float, cfa.CONF_2ND_CANDIDATE)  * 100 AS Confidence2nd,
     TRY_CONVERT(float, cfa.[TIME])                    AS ExtractionTimeMs,
-    -- 0/100 FLOATS, not 0/1 ints: the reporting layer emits a bare AVG(col) and
-    -- T-SQL integer-divides AVG over an int column. As floats, AVG() *is* the
-    -- percentage, with no post-maths.
-    CASE WHEN cfa.VALUE_BEFORE_VALIDATION <> '' THEN 100e0 ELSE 0e0 END
+    CASE WHEN cfa.VALUE_BEFORE_VALIDATION <> '''' THEN 100e0 ELSE 0e0 END
                                                       AS ExtractedPct,
-    CASE WHEN cfa.VALUE_BEFORE_VALIDATION <> '' AND cfa.[RESULT] = 'Equal'
+    CASE WHEN cfa.VALUE_BEFORE_VALIDATION <> '''' AND cfa.[RESULT] = ''Equal''
          THEN 100e0 ELSE 0e0 END                      AS CorrectPct,
-    CASE WHEN cfa.[RESULT] = 'Different' THEN 100e0 ELSE 0e0 END
+    CASE WHEN cfa.[RESULT] = ''Different'' THEN 100e0 ELSE 0e0 END
                                                       AS DeviationPct,
     TRY_CONVERT(float, cfa.IS_SET_BY_MACHINE)         * 100 AS SetByMachinePct,
     TRY_CONVERT(float, cfa.IS_USER_VERIFIED)          * 100 AS UserVerifiedPct,
     TRY_CONVERT(float, cfa.IS_USER_ENTERED)           * 100 AS UserEnteredPct,
     TRY_CONVERT(float, cfa.IS_USER_MODIFIED)          * 100 AS UserModifiedPct,
     TRY_CONVERT(float, cfa.VALUE_FROM_CANDIDATE_LIST) * 100 AS FromCandidateListPct,
-    -- Octo emits hundreds of distinct "fields" per stream, most of them internal
-    -- bookkeeping. Filtering this to 100 narrows a report to the fields nexora
-    -- actually knows about. Widen it by adding dbo.FieldAliases rows, not by
-    -- editing this view.
     CASE WHEN fa.TargetKey IS NULL THEN 0e0 ELSE 100e0 END
                                                       AS MappedInNexoraPct,
     cfa.VALUE_ORIGIN                                  AS ValueOrigin,
@@ -116,27 +100,18 @@ SELECT
     cfa.STATUS_BEFORE_VALIDATION                      AS StatusBeforeValidation,
     cfa.STATUS_AFTER_VALIDATION                       AS StatusAfterValidation
 FROM cfa
--- The date join is keyed on Stream, never Customer: Privera has three telemetry
--- tables across two header tables, so a workitem id present in both would match
--- twice under a Customer key and silently double those rows.
 LEFT JOIN dates d
        ON d.Stream   = cfa.Stream
       AND d.Workitem = cfa.WORKITEM_ID COLLATE DATABASE_DEFAULT
--- COLLATE DATABASE_DEFAULT: NexoraDB is Latin1_General_CI_AS, the statistics DB
--- SQL_Latin1_General_CP1_CI_AS, and an uncollated cross-database string compare
--- is a hard error, not a warning.
 LEFT JOIN dbo.FieldAliases fa
        ON fa.SourceFieldName = cfa.FIELD COLLATE DATABASE_DEFAULT
 LEFT JOIN dbo.FieldLabels  fl ON fl.FieldKey = LOWER(fa.TargetKey)
--- Onboarded customers, every process (0125). 0111 also matched the process
--- name, which hid ElektroMaterial's legacy 01_Invoice_1 and Privera's
--- PriveraPostFields telemetry from customers who are otherwise fully onboarded.
--- The organization gate stays: Bucherer and Geberit carry no OrgCode and remain
--- out until they get an Organizations row.
 WHERE EXISTS (
         SELECT 1
         FROM dbo.ProcessSources ps
-        WHERE ps.ClientCode       = 'default'
+        WHERE ps.ClientCode       = ''default''
           AND ps.OrganizationCode = cfa.OrgCode
-      );
+      );';
+
+EXEC sp_executesql @sql;
 GO


### PR DESCRIPTION
## Summary
- The first deploy of #293 failed at "Apply DB migrations to PROD": 0125 hard-referenced `Bucherer_Collect_Field_Attributes`, which exists on INT only. 0123 and 0124 applied; the app pool was never stopped, so PROD still serves the previous version.
- 0125 is now built with the same table-aware dynamic SQL as 0110/0111 (PR #286), keeping its organization-only gate. Re-applied on INT and checksum re-blessed; the view dump regenerated.

## Test plan
- [x] 0125 re-run on INT: view returns 68,716 rows for Compass, ElektroMaterial and Privera (unchanged)
- [x] `db-migrate --env INT --dry-run` up-to-date after re-bless
- [ ] CI fast tier
- [ ] Deploy on main applies 0125-0127 to PROD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYoDTWGRSkh7RYEQjk775R