### PR TITLE
fix(test): fix stale magnifier-icon selectors in workitems e2e

### DIFF
--- a/tests/e2e/test_ui_chrome_regressions.py
+++ b/tests/e2e/test_ui_chrome_regressions.py
@@ -39,7 +39,7 @@ def test_search_placeholder_starts_clear_of_the_magnifier(nexora_server, page):
     page.goto(f"{nexora_server}/workitems")
     expect(page.locator('[data-testid="workitems-search"]')).to_be_visible()
 
-    icon = _box(page, '[data-testid="workitems-search"] ~ span i, .relative span.absolute i')
+    icon = _box(page, ".nx-wi-search i")
     field = _box(page, '[data-testid="workitems-search"]')
     text_starts_at = field["x"] + page.eval_on_selector(
         '[data-testid="workitems-search"]',
@@ -61,7 +61,7 @@ def test_clicking_the_magnifier_focuses_the_search_field(nexora_server, page):
     page.goto(f"{nexora_server}/workitems")
     expect(page.locator('[data-testid="workitems-search"]')).to_be_visible()
 
-    icon = _box(page, ".relative span.absolute i")
+    icon = _box(page, ".nx-wi-search i")
     page.mouse.click(icon["x"] + icon["width"] / 2, icon["y"] + icon["height"] / 2)
 
     focused = page.evaluate("document.activeElement && document.activeElement.id")


### PR DESCRIPTION
## Summary
- The console redesign (#299) replaced the search box's `.relative`/`.absolute` span wrapper with a plain `.nx-wi-search` div, so two e2e chrome-regression tests targeting the old selector went stale and started failing.
- Caught by the first-ever run of the new nightly e2e cron (deploy.yml run 34325446974).
- Updated both selectors to `.nx-wi-search i`.

## Test plan
- [x] `pytest tests/e2e/test_ui_chrome_regressions.py -k magnifier` against the live dev server — 2 passed
- [x] `pytest tests/unit/test_ui_chrome_regressions.py` — 17 passed (unaffected, already tracked the new markup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJiRHKYPd9XA4neGVV3xwk