### PR TITLE
docs: correct the local-dev venv path in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Nexora is a Flask web application (Python 3, WSGI) deployed on Windows/IIS, whic
 ## Environment & running
 
 - `ENVIRONMENT` (`INT` or `PROD`) selects the env file; `nx_lib/config.py` loads `env/{ENVIRONMENT}.env`. Sanitised templates: `env/*.env.example`.
-- **Local dev:** venv at `./venv`, `pip install -r requirements.txt`, `ENVIRONMENT=INT`, `python nx_main.py`. WSGI handler is `nx_main.app`.
+- **Local dev:** `.venv` via `uv venv && uv sync` (or `bootstrap.ps1`), `ENVIRONMENT=INT`, `.venv\Scripts\python.exe nx_main.py`. WSGI handler is `nx_main.app`. `requirements*.txt` are generated from `uv.lock` for the IIS deploy path — never install from them locally. Full setup: `CONTRIBUTING.md`.
 - **Production:** IIS + HttpPlatformHandler → `waitress` (32 threads). `web.config` is the whole hosting contract — it starts waitress, sets `ENVIRONMENT=PROD` / `PYTHONPATH`, trusts `X-Forwarded-For`, logs stdout to `var/logs/system/waitress-stdout*`. Note `path="*"`: **waitress serves `/static`, not IIS**. See `docs/howto/iis.md`. (`wfastcgi` retired in v3.2.3.)
 - **Public tunnel** (SYAPP01 only): ngrok today (`docs/howto/ngrok.md`), Cloudflare Tunnel prepared, cutover pending (`docs/howto/cloudflare-tunnel.md`).
 


### PR DESCRIPTION
One line in `CLAUDE.md`. It said:

> **Local dev:** venv at `./venv`, `pip install -r requirements.txt`, …

There is no `./venv`. The venv is `.venv`, provisioned by uv — which is what
`CONTRIBUTING.md`, `docs/howto/nx.md` and `bootstrap.ps1` have all said for a
while. `requirements.txt` is a generated `uv export` for the IIS deploy path on
SYAPP01, not a local install route, so it's labelled as such now.

Worth fixing rather than shrugging at, for two reasons.

`CLAUDE.md` is the one file injected into every session, so a stale instruction
there is the most expensive place to have one — and `.gitignore` ignores both
`venv/` and `.venv`, so anyone following it creates a `venv/` that looks
perfectly fine while `nx` and the pre-commit hooks keep looking in `.venv`. No
error, just a setup that quietly isn't the one everything else expects.

It also cost a push today. The old pre-push hook was `entry: python -m pytest`
with `language: system`, and bare `python` on Windows resolves to the Store
"app execution alias" stub, which exits **9009** without running anything — so
the gate reported a failure having run zero tests. (That hook is gone now,
removed in a169efd2, and CONTRIBUTING.md already warns about the stub in its
setup block — it just never made it into CLAUDE.md.)

Docs-only, so `deploy.yml`'s `!**.md` filter skips the pipeline entirely — no
CI run, no deploy, no restart. `CLAUDE.md` isn't in the Confluence sync list
either, so nothing republishes.
