### PR TITLE
feat(reporting): Eddard cycles three report variants (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Eddard builds three different reports** (#272) — the reporting
+  assistant's waiting animation now cycles through three report layouts
+  instead of replaying one: the KPI card (bars + trend line, tossed in from
+  the lower left), a pipeline-measures table with a donut (dropped in from
+  above), and a weekly digest with progress bars and a sparkline (flung in
+  from the right). Each wrap of the build counter hands over to the next, so
+  a long wait keeps changing. The live preview of the agent's real numbers
+  (#212) now writes into whichever layout is on screen. Design:
+  `docs/design/eddard_animation_variety/`.
 - **Workitems overview: console redesign (part 2)** — the inline detail panel
   (shared with the reporting drill drawer and prepared_documents' preview
   modal) restyled to match part 1 (#299). Stage stepper redrawn as accent

--- a/docs/howto/reporting.md
+++ b/docs/howto/reporting.md
@@ -1726,7 +1726,8 @@ blinks, looks around, winks and hops. Files:
   picker; the core stays black in both themes (same rule as `.bh-core`).
 - `templates/js/_eddard_js.html` — one shared timer walking the idle mood
   sequence, plus `window.NexoraEddard.startBuild/stopBuild(stage)` for the
-  build loop (0→5, 1300 ms per step, wraps).
+  build loop (0→5, 1300 ms per step; each wrap advances to the next of the
+  three report variants).
 
 Placements: the top-bar toggle (22px), the chat panel header (24px), the empty
 thread (88px) and the AI-insight card head on Simple (20px). The three inline
@@ -1739,10 +1740,18 @@ pointer is fresh) and `sparks=true` (the handoff's three drifting ambient
 dots). Hovering a calm mark's parent perks him up (1px lift, wide eyes).
 
 While a turn runs, the progress ticker gets the `stage()` macro, which flings
-a report together (title → KPI → bars → trend → Ready badge) beside the real
-agent steps, with per-piece choreography: a one-shot `edThrow` fling and card
-settle as each piece lands, an orbiting spark while working, and the handoff's
-celebrate pose on Ready. The stage starts with placeholder copy but becomes a
+a report together beside the real agent steps, with per-piece choreography: a
+one-shot `edThrow` fling and card settle as each piece lands, an orbiting
+spark while working, and the handoff's celebrate pose on Ready. **Three report
+variants take turns**, one per build loop (#272), so a slow answer never
+replays the same card: `0` a KPI report (title → KPI → bars → trend line,
+tossed in from the lower left), `1` a pipeline-measures table with a donut
+(dropped in from above), `2` a weekly digest with progress bars and a
+sparkline (flung in from the right). Each slot declares `data-ed-step` (the
+build step it appears at) and `data-ed-var` (the variant that owns it; absent
+= every variant, as for the Ready badge), and the controller shows a slot when
+both match — adding a variant is markup, not JS. Design:
+`docs/design/eddard_animation_variety/`. The stage starts with placeholder copy but becomes a
 **live preview of the actual answer**: `ask_agentic_iter` yields a
 `tool_result` event after every tool call (key `output`, never `result` — that
 key terminates every consumer's loop), the view distills it through
@@ -1750,8 +1759,11 @@ key terminates every consumer's loop), the view distills it through
 total + series from `run_definition`/`run_sql` rows — first numeric cell per
 row, capped to the last 12) into a `{"phase": "preview"}` NDJSON line, and
 `NexoraEddard.setPreview()` swaps the mock report's title, compact-formatted
-total (the canned +8.3% delta hides next to real data), bar heights and trend
-line for the real numbers. Raw tool output never reaches the client from a
+total (the canned +8.3% delta hides next to real data), bar heights, progress
+fills, trend line and sparkline for the real numbers. It writes through
+`data-ed-preview` attributes rather than per-variant selectors, so the live
+numbers land in whichever variant is on screen when the event arrives (the
+donut keeps its canned ratio — a series is not a share). Raw tool output never reaches the client from a
 progress line. Everything is `aria-hidden` (decorative; the visible
 status text carries the meaning) and `prefers-reduced-motion` holds each loop
 on its resting frame. Source of truth for geometry, mood table and timings:

--- a/static/css/eddard.css
+++ b/static/css/eddard.css
@@ -227,6 +227,73 @@
   animation: edBadge .5s cubic-bezier(.34, 1.56, .64, 1) both;
 }
 
+/* --- variant 1: measures table + donut (drops in from above) -------------- */
+/* The group itself stays put -- each row drops in on its own, staggered. */
+.ed-rc-rows { display: flex; flex-direction: column; animation: none !important; }
+.ed-rc-rows > span {
+  display: flex; justify-content: space-between; gap: 8px; padding: 3px 0;
+  border-bottom: 1px solid var(--nx-border, #eef0f3);
+  font: 400 10px var(--nx-font, Inter, sans-serif);
+  animation: edTossTop .55s cubic-bezier(.34, 1.4, .6, 1) .05s both;
+}
+.ed-rc-rows > span:nth-child(2) { animation-delay: .15s; }
+.ed-rc-rows > span i { font-style: normal; font-weight: 600; color: var(--nx-text-sec, #57617a); }
+.ed-rc-rows > span b { font-weight: 700; color: var(--nx-text, #101623); }
+.ed-rc-rows > span.ed-rc-rows__total { border-bottom: 0; padding-bottom: 0; }
+.ed-rc-rows > span.ed-rc-rows__total i { color: var(--nx-text, #101623); font-weight: 700; }
+.ed-rc-rows > span.ed-rc-rows__total b { color: var(--nx-accent, #4f46e5); font-weight: 800; }
+
+.ed-rc-donut { display: flex; align-items: center; gap: 10px; }
+.ed-rc-donut svg { width: 36px; height: 36px; flex: none; }
+.ed-rc-donut__track { stroke: var(--nx-border, #eef0f3); }
+.ed-rc-donut__arc {
+  stroke: var(--nx-accent, #4f46e5);
+  stroke-dashoffset: 47;              /* ~53% sweep, per the handoff */
+  animation: edDraw100 .8s ease-out both;
+}
+.ed-rc-donut > span { display: flex; flex-direction: column; gap: 3px; }
+.ed-rc-donut > span i {
+  font: 600 9px var(--nx-font, Inter, sans-serif); font-style: normal;
+  color: var(--nx-text-sec, #57617a);
+}
+.ed-rc-donut > span i::before {
+  content: ""; display: inline-block; width: 6px; height: 6px; margin-right: 5px;
+  border-radius: 50%; background: var(--nx-accent, #4f46e5);
+}
+.ed-rc-donut > span i.is-rest::before { background: var(--nx-border, #eef0f3); }
+
+/* --- variant 2: big number + progress bars + sparkline (flung from right) -- */
+.ed-rc-big { display: flex; align-items: baseline; gap: 6px; }
+.ed-rc-big__num { font: 800 18px var(--nx-font, Inter, sans-serif); color: var(--nx-text, #101623); }
+.ed-rc-big__label { font: 600 9px var(--nx-font, Inter, sans-serif); color: var(--nx-text-sec, #57617a); }
+
+.ed-rc-prog { display: flex; flex-direction: column; gap: 5px; }
+.ed-rc-prog > span { display: flex; align-items: center; gap: 6px; }
+.ed-rc-prog > span i {
+  flex: none; width: 68px; font-style: normal; white-space: nowrap;
+  font: 600 9px var(--nx-font, Inter, sans-serif); color: var(--nx-text-sec, #57617a);
+}
+.ed-rc-prog > span b {
+  flex: 1; height: 5px; border-radius: 3px; overflow: hidden;
+  background: var(--nx-border, #eef0f3);
+}
+.ed-rc-prog > span b u {
+  display: block; height: 100%; border-radius: 3px;
+  background: var(--nx-accent, #4f46e5);
+  transform-origin: left; animation: edGrowX .5s ease-out both;
+}
+
+.ed-rc-spark { width: 100%; height: 24px; }
+.ed-rc-spark polyline { stroke: var(--nx-accent, #4f46e5); animation: edDraw100 .9s ease-out both; }
+
+/* Each variant throws its pieces in from its own direction (handoff 8a). */
+.ed-rc[data-ed-var="1"] > [data-ed-step] { animation-name: edTossTop; }
+.ed-rc[data-ed-var="2"] > [data-ed-step] { animation-name: edTossR; }
+/* ...except the donut, which pops in like the Ready badge. */
+.ed-rc[data-ed-var="1"] > .ed-rc-donut {
+  animation: edBadge .5s cubic-bezier(.34, 1.56, .64, 1) both;
+}
+
 /* Tiny settle bounce of the card as each piece lands (retriggered per piece). */
 .ed-rc.ed-rc--settle { animation: edSettle .3s ease-out; }
 @keyframes edSettle {
@@ -240,8 +307,24 @@
   72%  { transform: translate(6px, -5px) scale(1.06) rotate(4deg); }
   100% { transform: translate(0, 0) scale(1) rotate(0); opacity: 1; }
 }
+@keyframes edTossTop {
+  0%   { transform: translateY(-58px) scale(.55); opacity: 0; }
+  55%  { opacity: 1; }
+  72%  { transform: translateY(4px) scale(1.05); }
+  100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+@keyframes edTossR {
+  0%   { transform: translate(150px, 10px) scale(.4) rotate(10deg); opacity: 0; }
+  55%  { opacity: 1; }
+  72%  { transform: translate(-4px, -3px) scale(1.06) rotate(-2deg); }
+  100% { transform: translate(0, 0) scale(1) rotate(0); opacity: 1; }
+}
 @keyframes edGrow  { from { transform: scaleY(0); } to { transform: scaleY(1); } }
+@keyframes edGrowX { from { transform: scaleX(0); } to { transform: scaleX(1); } }
 @keyframes edDraw  { from { stroke-dashoffset: 240; } to { stroke-dashoffset: 0; } }
+/* pathLength="100", so this one is viewBox-size independent. The donut holds
+   its ~53% sweep, hence the per-element stroke-dashoffset it settles on. */
+@keyframes edDraw100 { from { stroke-dashoffset: 100; } }
 @keyframes edBadge {
   0%   { transform: scale(0); opacity: 0; }
   60%  { transform: scale(1.15); opacity: 1; }
@@ -253,6 +336,11 @@
 @media (prefers-reduced-motion: reduce) {
   .ed-rc,
   .ed-rc > *,
+  .ed-rc-rows > span,
+  .ed-rc-prog > span,
   .ed-rc-bars i,
-  .ed-rc-line polyline { animation: none !important; }
+  .ed-rc-prog u,
+  .ed-rc-line polyline,
+  .ed-rc-spark polyline,
+  .ed-rc-donut__arc { animation: none !important; }
 }

--- a/templates/_eddard.html
+++ b/templates/_eddard.html
@@ -38,29 +38,76 @@
 {%- endmacro %}
 
 {# "Eddard builds a report" (design handoff behaviour 2): he flings each piece
-   of a report onto the card -- title, KPI, bars, trend line -- then pops a
-   green Ready badge and clears back to an empty page. Decorative placeholder
-   content (it is a loading animation, not the real report), hence aria-hidden
-   and untranslated copy.
+   of a report onto the card, then pops a green Ready badge and clears back to
+   an empty page. Decorative placeholder content (it is a loading animation,
+   not the real report), hence aria-hidden and untranslated copy.
+
+   Three report variants take turns, one per build loop (#272, design
+   docs/design/eddard_animation_variety): 0 = KPI + bars + trend line tossed in
+   from the lower left, 1 = a measures table + donut dropped in from above,
+   2 = big number + progress bars + sparkline flung in from the right.
 
    The stage is inert markup: js/_eddard_js.html walks the build counter and
-   unhides the slots, each of which plays its entrance animation on reveal. #}
+   unhides the slots, each of which plays its entrance animation on reveal.
+   Each slot declares when it belongs on the card:
+     data-ed-step  lowest build step at which it shows
+     data-ed-var   which variant owns it (absent = every variant)
+     data-ed-preview  which streamed value overwrites it (see setPreview)
+   ponytail: the handoff's per-step status row is left out -- the ticker above
+   the stage already shows the agent's real step labels. #}
 {% macro stage(testid='') -%}
 <div class="ed-stage" {% if testid %}data-testid="{{ testid }}" {% endif %}aria-hidden="true">
   {{ mark(72, state='working', cls='ed-stage__mascot') }}
-  <div class="ed-rc">
+  <div class="ed-rc" data-ed-var="0">
     <div class="ed-rc-empty" data-ed-slot="empty">Empty report</div>
-    <div class="ed-rc-title" data-ed-slot="title" hidden>Monthly report</div>
-    <div class="ed-rc-kpi" data-ed-slot="kpi" hidden>
-      <span class="ed-rc-kpi__num">&euro;1.24M</span><span class="ed-rc-kpi__delta">&#9650; 8.3%</span>
+
+    {# variant 0 -- documents imported #}
+    <div class="ed-rc-title" data-ed-slot="title" data-ed-var="0" data-ed-step="1" data-ed-preview="title" hidden>Documents imported</div>
+    <div class="ed-rc-kpi" data-ed-slot="kpi" data-ed-var="0" data-ed-step="2" hidden>
+      <span class="ed-rc-kpi__num" data-ed-preview="total">3,482</span><span class="ed-rc-kpi__delta">&#9650; 8.3%</span>
     </div>
-    <div class="ed-rc-bars" data-ed-slot="bars" hidden>
+    <div class="ed-rc-bars" data-ed-slot="bars" data-ed-var="0" data-ed-step="3" data-ed-preview="bars" hidden>
       {% for h in [34, 52, 26, 44, 58, 38] %}<i style="height: {{ h }}px; animation-delay: {{ 0.15 + loop.index0 * 0.1 }}s"></i>{% endfor %}
     </div>
-    <svg class="ed-rc-line" data-ed-slot="line" viewBox="0 0 260 44" preserveAspectRatio="none" fill="none" hidden focusable="false">
+    <svg class="ed-rc-line" data-ed-slot="line" data-ed-var="0" data-ed-step="4" data-ed-preview="line" viewBox="0 0 260 44" preserveAspectRatio="none" fill="none" hidden focusable="false">
       <polyline points="0,38 44,26 88,30 132,14 176,20 220,6 260,12" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
-    <span class="ed-rc-badge" data-ed-slot="badge" hidden>Ready</span>
+
+    {# variant 1 -- pipeline measures #}
+    <div class="ed-rc-title" data-ed-slot="titleT" data-ed-var="1" data-ed-step="1" data-ed-preview="title" hidden>Pipeline measures</div>
+    <div class="ed-rc-rows" data-ed-slot="rows1" data-ed-var="1" data-ed-step="2" hidden>
+      <span><i>Backlog</i><b data-ed-preview="total">214</b></span>
+      <span><i>Documents imported</i><b>3,482</b></span>
+    </div>
+    <div class="ed-rc-rows" data-ed-slot="rows2" data-ed-var="1" data-ed-step="3" hidden>
+      <span><i>Documents exported</i><b>3,190</b></span>
+      <span class="ed-rc-rows__total"><i>Field extraction</i><b>96.4%</b></span>
+    </div>
+    <div class="ed-rc-donut" data-ed-slot="donut" data-ed-var="1" data-ed-step="4" hidden>
+      <svg viewBox="0 0 60 60" fill="none" focusable="false">
+        <circle class="ed-rc-donut__track" cx="30" cy="30" r="24" stroke-width="9"/>
+        <circle class="ed-rc-donut__arc" cx="30" cy="30" r="24" stroke-width="9" pathLength="100"
+                stroke-dasharray="100" stroke-linecap="round" transform="rotate(-90 30 30)"/>
+      </svg>
+      <span><i>Extracted 96%</i><i class="is-rest">Pending 4%</i></span>
+    </div>
+
+    {# variant 2 -- weekly digest #}
+    <div class="ed-rc-title" data-ed-slot="titleD" data-ed-var="2" data-ed-step="1" data-ed-preview="title" hidden>Weekly digest</div>
+    <div class="ed-rc-big" data-ed-slot="bignum" data-ed-var="2" data-ed-step="2" hidden>
+      <span class="ed-rc-big__num" data-ed-preview="total">214</span><span class="ed-rc-big__label">documents in backlog</span>
+    </div>
+    <div class="ed-rc-prog" data-ed-slot="progress" data-ed-var="2" data-ed-step="3" data-ed-preview="progress" hidden>
+      {% for label, pct in [('Imported', 82), ('Exported', 54), ('Field extraction', 96)] %}
+      <span><i>{{ label }}</i><b><u style="width: {{ pct }}%; animation-delay: {{ 0.05 + loop.index0 * 0.1 }}s"></u></b></span>
+      {% endfor %}
+    </div>
+    <svg class="ed-rc-spark" data-ed-slot="spark" data-ed-var="2" data-ed-step="4" data-ed-preview="spark" viewBox="0 0 200 32" preserveAspectRatio="none" fill="none" hidden focusable="false">
+      <polyline points="0,26 33,18 66,22 100,8 133,16 166,4 200,10" pathLength="100" stroke-dasharray="100"
+                stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+
+    <span class="ed-rc-badge" data-ed-slot="badge" data-ed-step="5" hidden>Ready</span>
   </div>
 </div>
 {%- endmacro %}

--- a/templates/js/_eddard_js.html
+++ b/templates/js/_eddard_js.html
@@ -70,16 +70,16 @@
   /* "Eddard builds a report" (handoff behaviour 2). The build counter walks
      0->5 every 1300ms and wraps, unhiding one more report slot each step; the
      entrance animations are pure CSS and (re)fire because the slot goes from
-     display:none to shown. Callers own the lifetime -- start it when a request
-     goes out, stop it when the answer lands. */
+     display:none to shown. Each wrap also advances to the next of the three
+     report variants (#272), so a long wait doesn't replay one layout forever.
+     Callers own the lifetime -- start it when a request goes out, stop it when
+     the answer lands. */
   window.NexoraEddard = (function () {
     var REDUCED = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     var timers = new WeakMap();
+    var VARIANTS = 3;
 
-    // Lowest build step at which each slot is on the page.
-    var SLOTS = { title: 1, kpi: 2, bars: 3, line: 4, badge: 5 };
-
-    // toggleAttribute, not el.hidden: the trend line is an <svg>, and the
+    // toggleAttribute, not el.hidden: several slots are <svg>, and the
     // `hidden` IDL property is HTMLElement-only -- assigning it there sets a
     // dead expando and the element stays display:none.
     // Returns whether the slot just appeared, so paint() can fire the
@@ -99,12 +99,21 @@
       el.classList.add(cls);
     }
 
-    function paint(stage, build) {
+    // A slot is on the card when the build has reached its step and the
+    // variant it belongs to is the one playing (no data-ed-var = all of them).
+    function paint(stage, build, variant) {
+      var card = stage.querySelector(".ed-rc");
+      card.dataset.edVar = variant;
       show(stage, "empty", build === 0);
       var appeared = false;
-      Object.keys(SLOTS).forEach(function (name) {
-        if (show(stage, name, name === "badge" ? build === 5 : build >= SLOTS[name])) appeared = true;
-      });
+      var slots = stage.querySelectorAll("[data-ed-step]");
+      for (var i = 0; i < slots.length; i++) {
+        var el = slots[i];
+        var own = el.dataset.edVar;
+        var on = build >= +el.dataset.edStep && (own === undefined || +own === variant);
+        if (on && el.hasAttribute("hidden")) appeared = true;
+        el.toggleAttribute("hidden", !on);
+      }
       // Choreography: he flings each piece (edThrow) while working, settles
       // the card under it, and celebrates the Ready badge (handoff build
       // table: lean+glow on 1-4, hop-up pose on 5).
@@ -121,49 +130,77 @@
     // tool result into {title?, total?, series?} (stage_preview server-side),
     // and the mock report shows THOSE numbers instead of the hardcoded ones --
     // the animation becomes a preview of the actual answer.
+    // Every variant tags the pieces it can show real data in with
+    // data-ed-preview, so this writes to all three and whichever one is on
+    // screen when the event lands shows the live numbers (#272). The donut
+    // keeps its canned ratio -- a series is not a share.
+    function each(stage, name, fn) {
+      Array.prototype.forEach.call(
+        stage.querySelectorAll('[data-ed-preview="' + name + '"]'), fn);
+    }
+
+    // Rewrite a polyline to the series, in whatever viewBox it was drawn in.
+    function drawLine(svg, series, max) {
+      var box = svg.viewBox.baseVal;
+      var pts = series.map(function (v, idx) {
+        var x = Math.round(box.width * idx / (series.length - 1));
+        var y = Math.round(box.height * 0.86 - box.height * 0.73 * Math.max(0, v) / max);
+        return x + "," + y;
+      }).join(" ");
+      svg.querySelector("polyline").setAttribute("points", pts);
+    }
+
     function setPreview(stage, p) {
       if (!stage || !p) return;
       if (p.title) {
-        stage.querySelector(".ed-rc-title").textContent = p.title;
+        each(stage, "title", function (el) { el.textContent = p.title; });
       }
       if (typeof p.total === "number") {
-        var num = stage.querySelector(".ed-rc-kpi__num");
-        num.textContent = new Intl.NumberFormat(undefined,
+        var txt = new Intl.NumberFormat(undefined,
           { notation: "compact", maximumFractionDigits: 1 }).format(p.total);
+        each(stage, "total", function (el) { el.textContent = txt; });
         // The canned +8.3% delta is fiction -- drop it next to real data.
         stage.querySelector(".ed-rc-kpi__delta").hidden = true;
       }
       if (p.series && p.series.length) {
         var max = Math.max.apply(null, p.series) || 1;
         var vals = p.series.slice(-6);
-        var bars = stage.querySelectorAll(".ed-rc-bars i");
-        for (var i = 0; i < bars.length; i++) {
-          if (i < vals.length) {
-            bars[i].hidden = false;
-            bars[i].style.height = Math.round(6 + 52 * Math.max(0, vals[i]) / max) + "px";
-          } else {
-            bars[i].hidden = true;
+        each(stage, "bars", function (group) {
+          var bars = group.querySelectorAll("i");
+          for (var i = 0; i < bars.length; i++) {
+            bars[i].hidden = i >= vals.length;
+            if (i < vals.length) {
+              bars[i].style.height = Math.round(6 + 52 * Math.max(0, vals[i]) / max) + "px";
+            }
           }
-        }
+        });
+        each(stage, "progress", function (group) {
+          var rows = group.querySelectorAll("span");
+          var last = p.series.slice(-rows.length);
+          for (var i = 0; i < rows.length; i++) {
+            rows[i].hidden = i >= last.length;
+            if (i < last.length) {
+              rows[i].querySelector("u").style.width =
+                Math.round(100 * Math.max(0, last[i]) / max) + "%";
+            }
+          }
+        });
         if (p.series.length > 1) {
-          var pts = p.series.map(function (v, idx) {
-            var x = Math.round(260 * idx / (p.series.length - 1));
-            var y = Math.round(38 - 32 * Math.max(0, v) / max);
-            return x + "," + y;
-          }).join(" ");
-          stage.querySelector(".ed-rc-line polyline").setAttribute("points", pts);
+          each(stage, "line", function (svg) { drawLine(svg, p.series, max); });
+          each(stage, "spark", function (svg) { drawLine(svg, p.series, max); });
         }
       }
     }
 
     function startBuild(stage) {
       if (!stage || timers.has(stage)) return;
-      if (REDUCED) { paint(stage, 5); return; }   // hold the finished report
-      var build = 0;
-      paint(stage, build);
+      if (REDUCED) { paint(stage, 5, 0); return; }   // hold the finished report
+      var build = 0, variant = 0;
+      paint(stage, build, variant);
       timers.set(stage, setInterval(function () {
         build = (build + 1) % 6;
-        paint(stage, build);
+        if (build === 0) variant = (variant + 1) % VARIANTS;   // next report type
+        paint(stage, build, variant);
       }, 1300));
     }
 

--- a/tests/e2e/test_reporting_agent.py
+++ b/tests/e2e/test_reporting_agent.py
@@ -458,6 +458,44 @@ def test_chat_ticker_shows_eddard_building_a_report(nexora_server, page):
     assert steps[0] == "empty", steps
     assert steps[-1] == "title,kpi,bars,line,badge", steps
 
+    # Variety (#272): each wrap of the build counter hands over to the next of
+    # the three report layouts, so a long wait never replays one card. 10s
+    # covers a full 0->5 walk plus the wrap at the 1300ms beat.
+    cycle = page.evaluate("""() => new Promise((resolve) => {
+        const stage = document.getElementById('rpChatWorkingMascot').content.cloneNode(true)
+            .querySelector('.ed-stage');
+        document.getElementById('rpChatThread').appendChild(stage);
+        const card = stage.querySelector('.ed-rc');
+        const seen = [];
+        window.NexoraEddard.startBuild(stage);
+        const t = setInterval(() => {
+            const now = card.dataset.edVar + ':' + Array.from(
+                stage.querySelectorAll('[data-ed-slot]'))
+                .filter((el) => el.getBoundingClientRect().height > 0)
+                .map((el) => el.dataset.edSlot).join(',');
+            if (seen[seen.length - 1] !== now) seen.push(now);
+            if (now.startsWith('1:') && now.includes('donut')) {
+                clearInterval(t);
+                window.NexoraEddard.stopBuild(stage);
+                stage.remove();
+                resolve(seen);
+            }
+        }, 100);
+        setTimeout(() => {
+            clearInterval(t);
+            window.NexoraEddard.stopBuild(stage);
+            stage.remove();
+            resolve(seen);
+        }, 14000);
+    })""")
+    # variant 0 builds its own pieces, then variant 1 takes over with its own
+    variants = [s.split(":")[0] for s in cycle]
+    assert variants[0] == "0" and "1" in variants, cycle
+    assert any(s.startswith("0:") and "kpi" in s for s in cycle), cycle
+    assert any(s.startswith("1:") and "rows1" in s for s in cycle), cycle
+    # no slot leaks across variants -- variant 1 never shows variant 0's pieces
+    assert not any(s.startswith("1:") and ("kpi" in s or "bars" in s) for s in cycle), cycle
+
     # Live preview + choreography (#212 follow-up): setPreview swaps the mock
     # report's hardcoded copy for the streamed real numbers (title, compact
     # total, per-value bars, no fake delta), and the celebrate class carries


### PR DESCRIPTION
Closes #272.

Eddard's "building a report" animation replayed one card for the whole wait.
It now cycles the three variants from the handoff at
`docs/design/eddard_animation_variety/`, one per build loop:

| variant | card | entrance |
|---|---|---|
| 0 | KPI report — title, KPI, bars, trend line (unchanged) | tossed in from the lower left (`edToss`) |
| 1 | pipeline-measures table + donut | dropped in from above (`edTossTop`) |
| 2 | weekly digest — big number, progress bars, sparkline | flung in from the right (`edTossR`) |

**Structure.** Each slot declares `data-ed-step` (the build step it lands at)
and `data-ed-var` (which variant owns it; absent = all, as for the Ready
badge). The controller shows a slot when both match, which let the hardcoded
slot map go — a fourth variant would be markup only.

**Live preview.** `setPreview()` now writes through `data-ed-preview`
attributes rather than variant-0 selectors, so the streamed real numbers
(#212) land in whichever layout is on screen: title, total, bar heights,
progress fills, trend line and sparkline (the line drawing generalised to read
its own viewBox). The donut keeps its canned ratio — a series is not a share.

**Deliberately not built:** the handoff's per-step status row ("Adding
title…", "Counting imports…"). The ticker directly above the stage already
shows the agent's *real* step labels, which beats canned ones. Chart captions
were likewise left off, matching the existing compact adaptation of variant 0.

### Verification
- Drove the real `stage()` macro + `_eddard_js.html` + `eddard.css` in a
  browser and confirmed the full sequence: `v0 empty→title→kpi→bars→line→badge`,
  then `v1 …rows1→rows2→donut→badge`, then `v2 …bignum→progress→spark→badge`,
  then back to v0 — with no slot leaking across variants.
- Confirmed `setPreview` rewrites titles/totals in all three layouts, bar
  heights, progress widths, and both polylines from one event.
- Extended `tests/e2e/test_reporting_agent.py` to assert the handover and the
  no-leak property in the real chat ticker; the existing assertions for the
  variant-0 walk and the preview are untouched and still pass by construction.
- Screenshots of all three variants sent to the requester.

⚠️ The e2e suite itself was **not run locally**: a parallel session holds the
main checkout, so this was built in a `git worktree`, which has no `env/` files
(they are gitignored, and copying them is blocked) and therefore no DB. CI's
run is the first execution of the new assertions. The SQL pre-commit hooks were
skipped via the documented `SQL_SYNC_SKIP=1` for the same reason — this change
touches no SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJiRHKYPd9XA4neGVV3xwk