### PR TITLE
fix(reporting): wrap the view toolbar so wells stops eating clicks (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,15 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and nothing bleeds in beside it; the editor preview re-runs on every change.
 
 ### Fixed
+- **The Forecast checkbox in the Advanced reporting toolbar was unclickable at
+  narrower window widths** (#285). The builder is a `260px 1fr 300px` grid, and
+  at a 1280px-wide window the middle results column collapses to 200px while the
+  Grid/Chart/Pivot + Forecast cluster needs 273px. It was `inline-flex` with
+  `flex-wrap: nowrap`, so it could neither shrink nor wrap and spilled 94px into
+  the wells column, which is later in the DOM and therefore painted over the
+  checkbox and swallowed its clicks. The cluster wraps now. This was filed as an
+  e2e failure and the test skipped, but it affected real users at that width too
+  — 1280 is an ordinary laptop viewport.
 - **The date picker is readable in dark mode on every page that has one, not
   just the dashboard.** The flatpickr overrides sat in `static/css/dashboard.css`,
   which only two templates load, while eleven templates open a calendar — so

--- a/static/css/reporting.css
+++ b/static/css/reporting.css
@@ -860,6 +860,11 @@ body.nx-app {
 /* View toggle (Grid / Chart / Pivot) → segmented, matches mode toggle */
 .reporting-view-toggle {
   display: inline-flex;
+  /* Wrap, don't overflow (#285). The middle grid track collapses to ~200px at
+     1280px wide, while this cluster needs ~273px; nowrap made it spill 94px
+     into the .reporting-wells column, which is later in DOM order and so
+     painted over the Forecast checkbox and swallowed its clicks. */
+  flex-wrap: wrap;
   gap: 3px; padding: 3px;
   background: var(--nx-sunken);
   border: 1px solid var(--nx-border);

--- a/tests/e2e/test_reporting.py
+++ b/tests/e2e/test_reporting.py
@@ -474,10 +474,6 @@ ADV_FC_STUB_METRICS = {
 
 
 @pytest.mark.flaky_e2e
-@pytest.mark.skip(
-    reason="#285: .reporting-wells intercepts clicks on the forecast toggle -- "
-    "real CSS layering bug, reproduces 100% (not flaky), needs frontend investigation"
-)
 def test_advanced_forecast_toggle_and_grid_rows(nexora_server, page):
     """Task 7: the Advanced results toolbar's Forecast checkbox appears only
     once the definition is forecast-eligible (single grained date column +


### PR DESCRIPTION
Closes #285 — and it turned out to be a real user-facing bug, not just an e2e
failure.

## What I measured

Dropped the skip marker, added a temporary diagnostic at the failing point, and
read the actual geometry (viewport 1280x720):

```
results  track  x=680  w=200   right=880      <- middle column is 200px
wells    track  x=900  w=300   right=1200
viewToggle      x=701  w=273   right=974      <- overflows results by 94px
forecastWrap    x=905  w=65                   <- lands inside wells (900..1200)
click point     913, 379
elementsFromPoint -> ["aside.reporting-wells", "input#rpForecast", ...]
rpAnimPresent   false
```

## Cause

The builder is `grid-template-columns: 260px 1fr 300px`. With ~400px of page
chrome and 40px of gaps, the `1fr` middle track resolves to **200px** at a
1280px-wide window. The Grid/Chart/Pivot + Forecast + horizon cluster needs
**273px**, and `.reporting-view-toggle` was `display: inline-flex` with
`flex-wrap: nowrap` — so it could neither shrink nor wrap, and spilled 94px past
the results column.

`.reporting-results` is `overflow: visible`, so nothing clipped the spill, and
`.reporting-wells` is `position: static` with no `z-index` but **later in DOM
order** — so it painted over the overflowing part of the toolbar and took the
pointer events. That is exactly what Playwright was reporting; the checkbox
really is visible, enabled and stable, it just has a card sitting on top of it.

Both of your hypotheses hold up: the `min-width: 0` from the "wide result no
longer widens the whole builder" change is what lets the track collapse below
its content, and the `.rp-anim` entrance animation is not involved
(`rpAnimPresent` was `false` at the failure point).

## Fix

One property — `flex-wrap: wrap` on `.reporting-view-toggle`, so the cluster
wraps inside its own column instead of overflowing. That is already the pattern
used for the sibling cluster at `reporting.css:424`.

Skip marker removed. The test passes first try (it previously failed 100% and
survived reruns), and all **13** tests in `tests/e2e/test_reporting.py` pass
together.

## Worth knowing: this affected real users

1280x720 is an ordinary laptop viewport, not a test-only condition. Anyone with
a window around that width could not tick the Forecast checkbox — the click
landed on the wells card. Because the test was skipped, that had no visible
signal.

## Deliberately not fixed here

A 200px results pane at 1280px is poor in its own right — the main content
column ends up the narrowest of the three. Fixing that properly means `minmax()`
on the middle track, which reintroduces the whole-builder horizontal overflow
that `min-width: 0` was added to prevent, so it needs the builder to scroll or
collapse to one column earlier. That is a layout decision and yours to make, so
I have left it alone rather than bundling it into a click fix.
