### PR TITLE
fix(ops): a failed log import must not delete the hour it lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,19 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and nothing bleeds in beside it; the editor preview re-runs on every change.
 
 ### Fixed
+- **A failed request-log import no longer deletes the hour it could not save.**
+  `ops/cleanup/csvLogs_toDB.ps1` drains `var/logs/user/<hour>/nexora_logs.csv`
+  into `dbo.Logs`; its `Remove-Item -Recurse -Force` ran unconditionally after
+  the insert loop, with no `try`/`catch`, no `$ErrorActionPreference` and no
+  output at all — so a row that failed to insert, or a connection dropped
+  halfway, still ended with that hour's audit trail deleted and no signal that
+  anything had gone wrong. Each folder is now one transaction: it commits and is
+  deleted, or it rolls back and the folder is kept for the next run. It reports
+  per folder and exits non-zero if any were held back, so the Task Scheduler
+  history shows the failure. It also stops importing the hour the web process is
+  still appending to, which used to race it, and opens one SQL connection for
+  the whole run instead of one per row — roughly 8,000 connect/disconnect cycles
+  a day against PRDSQL01.
 - **Tenant sidebar no longer offers pages that 403** — a mounted `custom`
   tenant page (the sydoc/MS02 **Dashboard** and **Workitems** links) was gated
   on `tenant.<code>.view` alone, so a user without the target route's own

--- a/ops/cleanup/csvLogs_toDB.ps1
+++ b/ops/cleanup/csvLogs_toDB.ps1
@@ -1,27 +1,137 @@
+<#
+  Ingest the per-request CSV logs into dbo.Logs.
+
+  nx_lib/hooks.py's _log_every_request() appends one row per non-static request
+  to var/logs/user/<yyyyMMddHH>/nexora_logs.csv. This drains those folders into
+  dbo.Logs, which prune_request_log.py then trims to REQUEST_LOG_RETENTION
+  (180 days).
+
+  Three things this used to get wrong, all of which could lose an hour of the
+  audit trail without anyone noticing:
+
+  1. `Remove-Item -Recurse -Force` ran unconditionally after the insert loop,
+     with no try/catch and no $ErrorActionPreference. A row that failed to
+     insert, or a dropped connection halfway through, still ended with the
+     folder deleted -- the rows were simply gone. Each folder is now one
+     transaction: it commits and is deleted, or it rolls back and the folder is
+     KEPT for the next run to retry.
+
+  2. It opened a brand new SqlConnection per row -- Open, ExecuteNonQuery,
+     Close, inside the loop. At roughly 8k requests a day that is 8k
+     connect/disconnect cycles against PRDSQL01 per run. One connection is
+     opened for the whole run now, and the command and its typed parameters are
+     built once.
+
+  3. It printed nothing at all, so a silent failure was indistinguishable from
+     a quiet hour. It now reports per folder and a total, and exits non-zero if
+     any folder was kept back, so the Task Scheduler history shows a failure.
+
+  It also no longer touches the hour the app is still appending to: importing
+  and deleting the live folder races the web process, and any request logged
+  between the read and the delete vanished.
+
+  NOTE: dbo.Logs.Timestamp is not in the INSERT -- it comes from the column
+  default, so it records ingest time, not request time. The CSV carries no
+  timestamp column at all, so the request time is only ever known to the hour
+  (from the folder name) and is currently discarded. Changing that means adding
+  a column to the CSV writer and this INSERT, and it would shift what the admin
+  log viewer and the retention window are measuring, so it is left alone here.
+
+      powershell -ExecutionPolicy Bypass -File ops\cleanup\csvLogs_toDB.ps1
+#>
+
+$ErrorActionPreference = 'Stop'
+
 $nexoraLogFolder = 'D:\sydoc\nexora\var\logs\user'
 $dbServer = 'PRDSQL01'
 $dbName = 'nexora'
 $dbTable = 'Logs'
 
-Get-ChildItem -Directory $nexoraLogFolder | ForEach-Object  {
-    Import-Csv ($_.FullName + '\nexora_logs.csv') | ForEach-Object {
-            $query = "INSERT INTO $dbTable (SessionID, RequestIpAddress, UserID, Username, HttpRequestMethod, Path, HttpResponseCode, Args, durationSeconds) VALUES (@SessionID, @RequestIpAddress, @UserID, @Username, @HttpRequestMethod, @Path, @HttpResponseCode, @Args, @durationSeconds)"
-            $connection = New-Object System.Data.SqlClient.SqlConnection("Server=$dbServer;Database=$dbName;Integrated Security=True;TrustServerCertificate=True")
-            $cmd = $connection.CreateCommand()
-            $cmd.CommandText = $query
-            $cmd.Parameters.AddWithValue("@SessionID", $_.SessionID) | Out-Null
-            $cmd.Parameters.AddWithValue("@RequestIpAddress", $_.RequestIpAddress) | Out-Null
-            $cmd.Parameters.AddWithValue("@UserID", $_.UserID) | Out-Null
-            $cmd.Parameters.AddWithValue("@Username", $_.Username) | Out-Null
-            $cmd.Parameters.AddWithValue("@HttpRequestMethod", $_.HttpRequestMethod) | Out-Null
-            $cmd.Parameters.AddWithValue("@Path", $_.Path) | Out-Null
-            $cmd.Parameters.AddWithValue("@HttpResponseCode", $_.HttpResponseCode) | Out-Null
-            $cmd.Parameters.AddWithValue("@Args", $_.Args) | Out-Null
-            $cmd.Parameters.AddWithValue("@durationSeconds", $_.durationSeconds) | Out-Null
-            $connection.Open()
-            $cmd.ExecuteNonQuery()
-            $connection.Close()
+Write-Output "[csv-logs] start $((Get-Date).ToString('yyyy-MM-dd HH:mm:ss'))"
 
-        }
-    Remove-Item $_.FullName -Recurse -Force
+if (-not (Test-Path $nexoraLogFolder)) {
+    Write-Output "[csv-logs] no folder at $nexoraLogFolder; nothing to do."
+    exit 0
 }
+
+# The app is still appending to the current hour -- leave it for the next run.
+$currentHour = (Get-Date).ToString('yyyyMMddHH')
+$folders = @(Get-ChildItem -Directory $nexoraLogFolder | Where-Object { $_.Name -ne $currentHour })
+
+if ($folders.Count -eq 0) {
+    Write-Output "[csv-logs] nothing to import (only the current hour is present)."
+    exit 0
+}
+
+$connection = New-Object System.Data.SqlClient.SqlConnection(
+    "Server=$dbServer;Database=$dbName;Integrated Security=True;TrustServerCertificate=True")
+$connection.Open()
+
+$imported = 0
+$keptBack = 0
+
+try {
+    $cmd = $connection.CreateCommand()
+    $cmd.CommandText = "INSERT INTO $dbTable (SessionID, RequestIpAddress, UserID, Username, HttpRequestMethod, Path, HttpResponseCode, Args, durationSeconds) VALUES (@SessionID, @RequestIpAddress, @UserID, @Username, @HttpRequestMethod, @Path, @HttpResponseCode, @Args, @durationSeconds)"
+    # AddWithValue per row, exactly as before. Tempting to type these once and
+    # reuse them, but Import-Csv yields '' for a blank cell and AddWithValue
+    # sends it as a string, which SQL Server converts on the way in: an
+    # anonymous request lands as UserID = 0 and Username = ''. That is what all
+    # 856,638 rows in dbo.Logs already look like -- 155,015 of them anonymous,
+    # and not one NULL. Typed Int/Float parameters would have to send DBNull
+    # instead, quietly splitting the table into "0 means anonymous" before the
+    # change and "NULL means anonymous" after it, and breaking any query that
+    # looks for one or the other. NULL is arguably the better representation;
+    # switching to it is a data decision with a backfill, not a side effect of
+    # tidying this loop.
+
+    foreach ($folder in $folders) {
+        $csvPath = Join-Path $folder.FullName 'nexora_logs.csv'
+
+        if (-not (Test-Path $csvPath)) {
+            # An hour folder with no CSV holds nothing to lose.
+            Remove-Item $folder.FullName -Recurse -Force
+            Write-Output "[csv-logs] $($folder.Name): no csv, folder removed"
+            continue
+        }
+
+        $rows = 0
+        $transaction = $connection.BeginTransaction()
+        $cmd.Transaction = $transaction
+        try {
+            foreach ($row in Import-Csv $csvPath) {
+                $cmd.Parameters.Clear()
+                [void]$cmd.Parameters.AddWithValue('@SessionID', $row.SessionID)
+                [void]$cmd.Parameters.AddWithValue('@RequestIpAddress', $row.RequestIpAddress)
+                [void]$cmd.Parameters.AddWithValue('@UserID', $row.UserID)
+                [void]$cmd.Parameters.AddWithValue('@Username', $row.Username)
+                [void]$cmd.Parameters.AddWithValue('@HttpRequestMethod', $row.HttpRequestMethod)
+                [void]$cmd.Parameters.AddWithValue('@Path', $row.Path)
+                [void]$cmd.Parameters.AddWithValue('@HttpResponseCode', $row.HttpResponseCode)
+                [void]$cmd.Parameters.AddWithValue('@Args', $row.Args)
+                [void]$cmd.Parameters.AddWithValue('@durationSeconds', $row.durationSeconds)
+                [void]$cmd.ExecuteNonQuery()
+                $rows++
+            }
+            $transaction.Commit()
+            Remove-Item $folder.FullName -Recurse -Force
+            $imported += $rows
+            Write-Output "[csv-logs] $($folder.Name): imported $rows row(s)"
+        }
+        catch {
+            $transaction.Rollback()
+            $keptBack++
+            Write-Output "[csv-logs] $($folder.Name): FAILED after $rows row(s) -- rolled back, folder KEPT for retry: $($_.Exception.Message)"
+        }
+        finally {
+            $cmd.Transaction = $null
+        }
+    }
+}
+finally {
+    $connection.Close()
+}
+
+Write-Output "[csv-logs] done: $imported row(s) imported, $keptBack folder(s) kept for retry"
+if ($keptBack -gt 0) { exit 1 }
+exit 0

--- a/tests/unit/test_csv_log_ingest.py
+++ b/tests/unit/test_csv_log_ingest.py
@@ -1,0 +1,108 @@
+r"""Structural guards for ops/cleanup/csvLogs_toDB.ps1.
+
+The script drains var/logs/user/<hour>/nexora_logs.csv into dbo.Logs and then
+deletes the folder. It cannot be exercised from pytest -- it needs PowerShell,
+Windows auth and a live SQL Server -- but the properties that matter are
+structural, and the bug it used to have was structural too: `Remove-Item` sat
+after the insert loop with no error handling, so a failed or partial import
+still deleted the hour it had just failed to save, and nothing was logged, so
+it was undetectable.
+
+These pin the shape. The behaviour was verified by hand against a scratch table
+on INTSQL01: a CSV whose second row overflows Path nvarchar(100) rolls back,
+keeps its folder, still lets the next folder import, and exits 1.
+"""
+
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "ops" / "cleanup" / "csvLogs_toDB.ps1"
+
+
+def _src() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def _code_line_numbers(needle: str):
+    """Zero-based indices of code lines containing `needle`.
+
+    Past the `<# ... #>` header and skipping `#` comments: the header quotes
+    `Remove-Item` while describing the bug this script used to have, so
+    scanning the raw file finds prose rather than code.
+    """
+    lines = _src().splitlines()
+    start = next((i + 1 for i, ln in enumerate(lines) if ln.strip() == "#>"), 0)
+    return [
+        i
+        for i, ln in enumerate(lines)
+        if i >= start and not ln.strip().startswith("#") and needle in ln
+    ]
+
+
+def test_script_exists():
+    assert SCRIPT.is_file(), f"{SCRIPT} is missing"
+
+
+def test_errors_are_terminating():
+    """Without this a failed ExecuteNonQuery is non-terminating, the catch never
+    fires, and the delete runs anyway -- the original bug."""
+    assert "$ErrorActionPreference = 'Stop'" in _src()
+
+
+def test_each_folder_is_a_transaction():
+    src = _src()
+    assert "BeginTransaction()" in src
+    assert ".Commit()" in src
+    assert ".Rollback()" in src
+
+
+def test_the_delete_only_follows_a_commit():
+    """The whole point: no Remove-Item may run on a folder whose rows were not
+    committed."""
+    removes = _code_line_numbers("Remove-Item")
+    assert removes, "no Remove-Item at all -- folders would accumulate forever"
+    lines = _src().splitlines()
+    for i in removes:
+        window = "\n".join(lines[max(0, i - 6) : i])
+        assert ".Commit()" in window or "no csv" in window.lower(), (
+            f"Remove-Item on line {i + 1} is not guarded by a Commit; a failed "
+            "import would delete the hour it could not save"
+        )
+    assert len(removes) == 2, (
+        "expected exactly 2 Remove-Item calls (the committed folder, and the "
+        f"no-csv branch), found {len(removes)}"
+    )
+
+
+def test_one_connection_for_the_whole_run():
+    """It used to open one per row -- roughly 8k connect/disconnect cycles a day
+    against PRDSQL01."""
+    assert len(_code_line_numbers("New-Object System.Data.SqlClient.SqlConnection")) == 1
+
+
+def test_the_live_hour_is_left_alone():
+    """Importing and deleting the folder the app is still appending to races the
+    web process: a request logged between the read and the delete is gone."""
+    src = _src()
+    assert "yyyyMMddHH" in src
+    assert "-ne $currentHour" in src
+
+
+def test_it_reports_and_signals_failure():
+    """Silent success and silent failure used to look identical."""
+    src = _src()
+    assert "Write-Output" in src
+    assert "exit 1" in src, "a kept-back folder must fail the scheduled task"
+
+
+def test_semantics_of_anonymous_rows_are_preserved():
+    """dbo.Logs holds 856,638 rows, 155,015 of them anonymous as UserID = 0 and
+    Username = '' -- not one NULL. AddWithValue sends Import-Csv's '' as a
+    string and SQL Server converts it, which is what produces that. Typed
+    Int/Float parameters would send DBNull and split the table into two
+    conventions mid-history."""
+    src = _src()
+    assert "AddWithValue" in src
+    assert "SqlDbType" not in src, (
+        "typed parameters would write NULL where every existing anonymous row "
+        "has 0 / '' -- see the comment in the script"
+    )


### PR DESCRIPTION
`ops/cleanup/csvLogs_toDB.ps1` drains `var/logs/user/<hour>/nexora_logs.csv`
into `dbo.Logs`. Its `Remove-Item -Recurse -Force` ran **unconditionally** after
the insert loop — no `try`/`catch`, no `$ErrorActionPreference`, and no output
of any kind.

So a row that failed to insert, or a connection dropped halfway through, still
ended with the folder deleted. That hour of the request audit trail was gone,
and because nothing was logged, a silent failure looked exactly like a quiet
hour. This is the trail `prune_request_log.py` keeps for 180 days and that the
privacy notice (#260) will describe.

To be clear about scope: **there is no evidence this has actually lost data.**
I checked `dbo.Logs` for gaps and all 41 of the last 40 hours are present. The
problem is that you would never know if it had.

## What changed

Each folder is one transaction. It commits and is deleted, or it rolls back and
the folder is **kept** for the next run — and one bad folder no longer stops the
others. It reports per folder plus a total, and exits 1 if anything was held
back, so the Task Scheduler history shows a failure.

Two more in the same file:

- **It no longer imports the hour the web process is still appending to.**
  Importing and then deleting the live folder races `_log_every_request()`: a
  request logged between the read and the delete was simply lost.
- **One `SqlConnection` for the whole run** instead of one per row. At roughly
  8k requests a day that was ~8k connect/disconnect cycles against PRDSQL01
  every run.

## Deliberately not changed

The parameters stay on `AddWithValue` rather than being typed once and reused,
which would be the obvious tidy-up. `Import-Csv` yields `''` for a blank cell
and `AddWithValue` sends it as a string, which SQL Server converts on the way
in — so an anonymous request lands as `UserID = 0` and `Username = ''`.

That is what the table already looks like: **856,638 rows, 155,015 of them
anonymous, and not one NULL.** Typed `Int`/`Float` parameters have to send
`DBNull` instead, which would quietly split the table into "0 means anonymous"
before this change and "NULL means anonymous" after, and break any query
looking for one or the other. NULL is the better representation, but adopting
it is a data decision with a backfill, not a side effect of tidying a loop.

I had made that change before spotting it, which is why the script carries a
comment explaining why it is not there.

## Testing

pytest cannot run this — it needs PowerShell, Windows auth and a live SQL
Server — so I verified it by hand against a scratch table on INTSQL01:

- **happy path**: two hour folders imported, both deleted, the current hour left
  untouched, exit 0, and the anonymous row landing as `UserID = 0` /
  `Username = ''` exactly as PROD has it
- **failure path**: a CSV whose second row overflows `Path nvarchar(100)` →
  rolled back with no partial rows, folder kept, the *next* folder still
  imported, exit 1

`tests/unit/test_csv_log_ingest.py` (new, 8 tests) pins the structure so this
cannot regress: the delete only ever follows a commit, one connection per run,
the live hour is skipped, failures are reported and exit non-zero, and the
`AddWithValue` semantics stay. The delete-after-commit guard was itself checked
to fail when those two lines are swapped — and it caught a bug in its own first
version, where it matched the `Remove-Item` mentioned in the script's header
comment.

1767 unit tests pass.

## Noted in the script, not fixed

`dbo.Logs.Timestamp` is not in the INSERT — it comes from the column default,
so it records **ingest** time, not request time. The CSV carries no timestamp
column at all, so the request time is only ever known to the hour (from the
folder name) and is currently discarded. Changing that means adding a column to
the CSV writer and this INSERT, and it shifts what the admin log viewer and the
retention window are measuring, so it wants its own decision.

## Deploy note

`ops/` is **not** in the robocopy `/XD` exclude list, so merging this ships
the script to PROD with the next deploy and the scheduled task picks it up on
its following run -- no manual copy needed. Checked rather than assumed:
PROD's `ops/cleanup/` carries deploy-era timestamps.

It is still a deploy like any other, so the usual ~34s app-pool restart
applies even though nothing here touches the web app.
