### PR TITLE
test(e2e): un-skip forecast toggle test, #285 no longer reproduces

### DIFF
--- a/tests/e2e/test_reporting.py
+++ b/tests/e2e/test_reporting.py
@@ -474,10 +474,6 @@ ADV_FC_STUB_METRICS = {
 
 
 @pytest.mark.flaky_e2e
-@pytest.mark.skip(
-    reason="#285: .reporting-wells intercepts clicks on the forecast toggle -- "
-    "real CSS layering bug, reproduces 100% (not flaky), needs frontend investigation"
-)
 def test_advanced_forecast_toggle_and_grid_rows(nexora_server, page):
     """Task 7: the Advanced results toolbar's Forecast checkbox appears only
     once the definition is forecast-eligible (single grained date column +


### PR DESCRIPTION
## Summary
Closes #285.

CSS layering bug (`.reporting-wells` intercepting clicks on the Advanced forecast toggle) was fixed as a side effect of the later Advanced-builder CSS rework (studio skin + panel/grid restructuring) that landed after the issue was filed. Ran the previously-skipped test 10x locally with `pytest-rerunfailures` disabled (`--reruns 0`): 10/10 clean passes, no interception.

## Change
Removes the `@pytest.mark.skip` on `test_advanced_forecast_toggle_and_grid_rows`.

## Verification
- `ENVIRONMENT=TEST pytest tests/e2e/test_reporting.py::test_advanced_forecast_toggle_and_grid_rows --reruns 0` — 10/10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)