### PR TITLE
feat(reporting): register Aveniq Xpert Statistics source (0128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Aveniq — Xpert Statistics reporting source** — migration `0128` registers
+  `SYDOC_Statistik.dbo.Xpert_Stats` (daily DPSI counts pushed by mail from the
+  Aveniq box, see `nx-sources/xpert/`) as a `table` source with three measures:
+  Documents, BFH new creditors, ZHAW workitems. Gated by
+  `reporting.source.xpert_stats.use`.
 - **Eddard builds three different reports** (#272) — the reporting
   assistant's waiting animation now cycles through three report layouts
   instead of replaying one: the KPI card (bars + trend line, tossed in from

--- a/docs/howto/reporting-guide.md
+++ b/docs/howto/reporting-guide.md
@@ -152,7 +152,8 @@ Management, Reporting and CSV Imports. Sydoc staff also see **Bucherer — EasyT
 (imported and exported documents, pages) and **Frigemo — Documents** (daily
 imported/exported documents and pages, deleted documents, invoices) and **Sydoc — Project Hours** (hours booked in
 bpsuite by customer, project package, task and user) and **MediaMarkt — Batches**
-(pieces scanned per batch, entered on the Sydoc tenant page). Clicking a source card in the rail opens its
+(pieces scanned per batch, entered on the Sydoc tenant page) and **Aveniq — Xpert Statistics**
+(daily document counts per DPSI client, BFH new creditors, ZHAW workitems). Clicking a source card in the rail opens its
 database **structure**, not a report — start reports with **New report**.
 
 **Click a source card** to look inside the database behind it (needs the

--- a/docs/howto/reporting.md
+++ b/docs/howto/reporting.md
@@ -1256,7 +1256,12 @@ loaded by the `nx-sources/bps/bps_project_report.py` collector; measures `Hours`
 (`mediamarkt_batches` over `SYDOC_Statistik.dbo.MediaMarkt_Batches`, the table behind the
 generated `/t/sydoc/mediamarkt` CRUD page; measures `Pieces scanned` = sum of
 `Pieces`, `Batches` = row count; `ScanDate` grainable, `DocType` K/D/KA and `Visum`
-as dimensions). The wizard's measure step walks
+as dimensions). `0128` registers **Aveniq — Xpert Statistics** (`xpert_stats` over
+`SYDOC_Statistik.dbo.Xpert_Stats`, the daily long-format counts mailed in from the
+Aveniq box and loaded by `nx-sources/xpert/importCSVtoSQL.py`; every measure is a
+conditional `sum` of `Cnt` on `Metric` so subsets never double-count — `Documents`
+= `Total`, `BFH new creditors`, `ZHAW workitems`; `ExportDate` grainable, `Client`
+the natural dimension). `SortOrder` 320. The wizard's measure step walks
 sources in `SortOrder` and splits a `Tenant — Thing` label at the em dash: one
 uppercase heading per tenant, a `.rs-choice-group-sublabel` per source. The
 tenant's lookup tables carry no measures and are not registered. Each source is gated by its own

--- a/sql/_migrations/NexoraDB/0128_seed_xpert_stats_source.sql
+++ b/sql/_migrations/NexoraDB/0128_seed_xpert_stats_source.sql
@@ -1,0 +1,46 @@
+-- 0128_seed_xpert_stats_source.sql
+-- Daily Aveniq/xpert DPSI counts land in SYDOC_Statistik.dbo.Xpert_Stats
+-- (pushed by mail from the Aveniq box, imported by nx-sources/xpert/
+-- importCSVtoSQL.py): one row per day / DPSI database / metric, long format,
+-- with the ZHAW breakdowns carrying a Dimension value. Register it as a generic
+-- 'table' source (0117 pattern). Measures are conditional sums on Metric so
+-- the subset metrics (BFH new creditors, ZHAW breakdowns) never double-count
+-- into the total. Permission follows reporting.source.<code>.use (0088);
+-- Enterprise Admin only (0106). Idempotent.
+
+INSERT INTO dbo.Permission (Code, Description)
+SELECT N'reporting.source.xpert_stats.use', N'Use the Aveniq Xpert Statistics source'
+WHERE NOT EXISTS (SELECT 1 FROM dbo.Permission WHERE Code = N'reporting.source.xpert_stats.use');
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.ReportingSources WHERE Code = 'xpert_stats')
+INSERT INTO dbo.ReportingSources
+    (Code, Kind, Label, Permission, Engine, Provider, BaseObject, ColumnsJSON, Enabled, SortOrder)
+VALUES (
+    'xpert_stats', 'curated', N'Aveniq — Xpert Statistics',
+    'reporting.source.xpert_stats.use', 'statistics', 'table', 'dbo.Xpert_Stats',
+    N'[{"field":"ExportDate","label":"Date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"Client","label":"Client","type":"string","filterable":true,"sortable":true},
+       {"field":"SourceDb","label":"Source database","type":"string","filterable":true,"sortable":true},
+       {"field":"Metric","label":"Metric","type":"string","filterable":true,"sortable":true},
+       {"field":"Dimension","label":"Dimension","type":"string","filterable":true,"sortable":true},
+       {"field":"Cnt","label":"Count","type":"number","filterable":true,"sortable":true}]',
+    1, 320);
+GO
+
+INSERT INTO dbo.ReportingMetrics
+    (Code, SourceId, Label, GermanLabel, FrenchLabel, ItalianLabel, Aggregation, BaseField, FilterJson, Description, Format, SortOrder)
+SELECT v.Code, v.SourceId, v.Label, v.De, v.Fr, v.It, v.Agg, v.BaseField, v.Filt, v.Descr, v.Fmt, v.SortOrder
+FROM (VALUES
+    ('xpert_stats_documents', 'xpert_stats', N'Documents', N'Dokumente', N'Documents', N'Documenti',
+        'sum', 'Cnt', N'[{"field":"Metric","op":"eq","value":"Total"}]',
+        N'Documents processed per day (the Total metric of every DPSI database)', 'int', 320),
+    ('xpert_stats_bfh_new_creditors', 'xpert_stats', N'BFH new creditors', N'BFH neue Kreditoren', N'BFH nouveaux créanciers', N'BFH nuovi creditori',
+        'sum', 'Cnt', N'[{"field":"Metric","op":"eq","value":"NeueKreditoren"}]',
+        N'BFH documents with the placeholder creditor 9999999999', 'int', 321),
+    ('xpert_stats_zhaw_workitems', 'xpert_stats', N'ZHAW workitems', N'ZHAW Workitems', N'ZHAW workitems', N'ZHAW workitem',
+        'sum', 'Cnt', N'[{"field":"Metric","op":"eq","value":"WorkItems"}]',
+        N'ZHAW Stat_ZHAW rows with a workitem id', 'int', 322)
+) AS v(Code, SourceId, Label, De, Fr, It, Agg, BaseField, Filt, Descr, Fmt, SortOrder)
+WHERE NOT EXISTS (SELECT 1 FROM dbo.ReportingMetrics m WHERE m.Code = v.Code);
+GO


### PR DESCRIPTION
## Summary
- Migration `0128` registers **Aveniq — Xpert Statistics** (`xpert_stats` over `SYDOC_Statistik.dbo.Xpert_Stats`) as a generic `table` source, `SortOrder` 320.
- Three measures, each a conditional `sum` of `Cnt` on `Metric` so subset rows never double-count into the total: Documents (`Total`), BFH new creditors, ZHAW workitems. `ExportDate` grainable, `Client` the natural dimension.
- New permission `reporting.source.xpert_stats.use` (Enterprise Admin trigger grants it).
- Docs: reporting howto, end-user guide, changelog.

The table is fed daily by `nx-sources/xpert` (extractor on the Aveniq box mails a CSV, puller + importer on prdimpexp01 load it). It already exists on PRDSQL01 with live rows.

## Test plan
- [x] Migration applied to INT
- [x] Simple wizard: Aveniq / Xpert Statistics measures listed, "Dokumente nach Client" runs (10 clients, generated SQL is the CASE-sum)
- [x] `pytest tests/unit -k "reporting and (source or metric or table_query)"` — 110 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)