### PR TITLE
fix(workitems): FILTER_DEFAULTS was read before its declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   old copy still writes — see `scripts/generali-import/README.md`.
 
 ### Fixed
+- **Workitems page loaded no rows** — the filter serialiser from #317 kept its defaults table in a `const` declared *after* the first fetch inside the same DOMContentLoaded handler, so the initial `/api/workitems` call died in the temporal dead zone (`Cannot access 'FILTER_DEFAULTS' before initialization`) and the table showed skeletons forever. The table now lives inside `buildFilterParams()`; an unfiltered page also no longer leaves a bare `?` in the address bar. A unit test pins the declaration's position.
 - **A failed request-log import no longer deletes the hour it could not save.**
   `ops/cleanup/csvLogs_toDB.ps1` drains `var/logs/user/<hour>/nexora_logs.csv`
   into `dbo.Logs`; its `Remove-Item -Recurse -Force` ran unconditionally after

--- a/static/js/workitems_overview.js
+++ b/static/js/workitems_overview.js
@@ -783,9 +783,14 @@ modalConfirmBtn.addEventListener('click', () => {
     // merely happens to also be 40. These track
     // nx_lib/workitems/query.py -> args.get('perPage', 40) and
     // nx_lib/views/workitems.py -> args.get('prcfW', 'all').
-    const FILTER_DEFAULTS = { prcfW: 'all', perPage: '40' };
-
     function buildFilterParams(filterForm, page) {
+        // Declared inside the function on purpose: this whole file runs in one
+        // DOMContentLoaded handler and fetchAndUpdateWorkitems() is called near
+        // the top of it, long before this point is reached. A const out here
+        // would still be in its temporal dead zone on that first call
+        // ("Cannot access 'FILTER_DEFAULTS' before initialization"), which is
+        // exactly what broke the PROD workitems page on 2026-09-10.
+        const FILTER_DEFAULTS = { prcfW: 'all', perPage: '40' };
         const params = new URLSearchParams();
 
         for (const el of filterForm.elements) {
@@ -834,7 +839,8 @@ modalConfirmBtn.addEventListener('click', () => {
         // Always the real requested perPage (40/100/200/500/1000), never
         // the fast-chunk override below -- the address bar/history entry
         // must reflect what the user actually asked for.
-        const newUrl = `${window.location.pathname}?${params.toString()}`;
+        const qs = params.toString();
+        const newUrl = window.location.pathname + (qs ? `?${qs}` : '');
         window.history.pushState({ path: newUrl }, '', newUrl);
 
         // Skeleton rows, single source of truth in workitems_overview.html (#189)

--- a/tests/unit/test_workitems_url_params.py
+++ b/tests/unit/test_workitems_url_params.py
@@ -60,6 +60,21 @@ def test_page_one_is_dropped():
     assert "if (page > 1) params.set('page', page);" in _js()
 
 
+def test_defaults_are_declared_inside_the_serialiser():
+    # The whole file runs in one DOMContentLoaded handler that calls
+    # fetchAndUpdateWorkitems() near its top. A `const` declared at handler
+    # level below that call is still in its temporal dead zone on the first
+    # call and throws -- which blanked the PROD workitems page on 2026-09-10.
+    js = _js()
+    fn = js.index("function buildFilterParams(")
+    decl = js.index("const FILTER_DEFAULTS = {")
+    assert decl > fn, "FILTER_DEFAULTS must live inside buildFilterParams, not at handler scope"
+    body = js[fn:decl]
+    assert (
+        body.count("{") - body.count("}") >= 1
+    ), "FILTER_DEFAULTS is not inside buildFilterParams' body"
+
+
 def test_js_perpage_default_matches_the_server():
     """query.py: per_page = int(args.get("perPage", 40))"""
     src = QUERY_PY.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- PROD workitems page showed skeleton rows forever after today's deploy: #317's `const FILTER_DEFAULTS` sits at DOMContentLoaded-handler scope *below* the initial `fetchAndUpdateWorkitems()` call in the same handler, so the first call died in the temporal dead zone (`Cannot access 'FILTER_DEFAULTS' before initialization`) and no `/api/workitems` request was ever sent.
- Move the table inside `buildFilterParams()`; drop the bare `?` an unfiltered page left in the address bar.
- Unit test pins the declaration inside the function (verified to fail against the previous file). Changelog entry under Unreleased/Fixed.

## Test plan
- [x] Reproduced on INT with main's JS in Playwright (console error above, no list request)
- [x] With the fix: `/api/workitems` 200, rows render (`var/screenshots/workitems-tdz-fix.png`)
- [x] `tests/unit/test_workitems_url_params.py` 10 passed
- [ ] CI fast tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEaXUciKKyDdZQ4uJkvywR