### PR TITLE
fix(workitems): tokenise the stage timeline's hardcoded whites (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,21 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   old copy still writes — see `scripts/generali-import/README.md`.
 
 ### Fixed
+- **Workitem stage timeline no longer paints white circles in dark mode**
+  (#326) — the stepper inside an expanded workitem row had `background: #fff`
+  written into three surfaces with no dark counterpart: the not-yet-started
+  stage circles, the running stage's circle, and the two buttons above the
+  document column. The running stage was the worst of them, because its icon
+  is `fa-circle-check` — a filled disc with the tick knocked *out* — so the
+  white showed through the tick and the whole node read as a bright bullseye,
+  the loudest thing on an otherwise dark row. All four now take
+  `var(--nx-card)`, and the pending stage label takes `var(--nx-text-meta)`
+  instead of a hardcoded `#c2c7cf` that sat at roughly 1.6:1 on white. Light
+  mode is unchanged (`--nx-card` is `#ffffff` there). The document page
+  surfaces keep their literal white on purpose — a scan is paper in both
+  themes — and a unit test pins which surfaces are tokenised and which are
+  deliberately not. The stylesheet is shared, so the generali pages,
+  `prepared_documents.html` and `reporting.html` get the fix too.
 - **Workitems page loaded no rows** — the filter serialiser from #317 kept its defaults table in a `const` declared *after* the first fetch inside the same DOMContentLoaded handler, so the initial `/api/workitems` call died in the temporal dead zone (`Cannot access 'FILTER_DEFAULTS' before initialization`) and the table showed skeletons forever. The table now lives inside `buildFilterParams()`; an unfiltered page also no longer leaves a bare `?` in the address bar. A unit test pins the declaration's position.
 - **A document nexora cannot load now says so, instead of showing an empty
   panel** (#321). When Octo refused to serve a document, the fetch returned the

--- a/static/css/workitems_overview.css
+++ b/static/css/workitems_overview.css
@@ -521,18 +521,23 @@ img.nx-wi-card__sheet { object-fit: cover; object-position: top; display: block;
    ============================================================ */
 .wi-detail-panel { padding: 18px 20px 20px; background: var(--nx-alt); }
 
-/* Stage stepper (readOnly consumers never render this block at all). */
+/* Stage stepper (readOnly consumers never render this block at all).
+   Surfaces are tokens, not #fff: --nx-card is #ffffff in light and #1e293b in
+   dark, so light mode is unchanged while dark mode stops painting white discs
+   on a dark panel. The circles carried a hardcoded #fff, and the current
+   stage's icon is fa-circle-check -- a disc with the tick knocked out -- so on
+   white it read as a bright bullseye, the loudest thing on the row (#326). */
 .wi-stepper { display: flex; align-items: center; padding-bottom: 16px; border-bottom: 1px solid var(--nx-border); }
 .wi-stepper__step { display: inline-flex; align-items: center; gap: 7px; white-space: nowrap; }
 .wi-stepper__icon {
   display: inline-flex; align-items: center; justify-content: center;
   width: 22px; height: 22px; border-radius: var(--nx-radius-pill);
-  background: #fff; color: var(--nx-border-strong); border: 1.5px solid var(--nx-border);
+  background: var(--nx-card); color: var(--nx-border-strong); border: 1.5px solid var(--nx-border);
   font-size: 9px; flex-shrink: 0; transition: all 0.2s ease;
 }
 .wi-stepper__icon.is-done { background: var(--nx-accent); color: #fff; border-color: var(--nx-accent); }
-.wi-stepper__icon.is-current { background: #fff; color: var(--nx-accent); border-color: var(--nx-accent); }
-.wi-stepper__label { font-size: 11px; font-weight: 500; color: #c2c7cf; }
+.wi-stepper__icon.is-current { background: var(--nx-card); color: var(--nx-accent); border-color: var(--nx-accent); }
+.wi-stepper__label { font-size: 11px; font-weight: 500; color: var(--nx-text-meta); }
 .wi-stepper__label.is-done { color: var(--nx-text-sec); }
 .wi-stepper__label.is-current { color: var(--nx-text); font-weight: 700; }
 .wi-stepper__line { flex: 1; height: 1.5px; background: var(--nx-border); margin: 0 10px; min-width: 24px; }
@@ -547,7 +552,7 @@ img.nx-wi-card__sheet { object-fit: cover; object-position: top; display: block;
 .wi-doc-fullbtn, .wi-show-sources-btn {
   margin-left: auto; display: inline-flex; align-items: center; gap: 5px;
   height: 24px; padding: 0 8px; border-radius: 7px; font-size: 11px; font-weight: 600;
-  background: #fff; color: var(--nx-text-sec); border: 1px solid var(--nx-border); cursor: pointer;
+  background: var(--nx-card); color: var(--nx-text-sec); border: 1px solid var(--nx-border); cursor: pointer;
 }
 .wi-doc-fullbtn:hover, .wi-show-sources-btn:hover { border-color: var(--nx-border-strong); color: var(--nx-text); }
 .wi-doc-fullbtn i, .wi-show-sources-btn i { color: var(--nx-text-meta); font-size: 9px; }

--- a/tests/unit/test_workitem_stepper_styles.py
+++ b/tests/unit/test_workitem_stepper_styles.py
@@ -1,0 +1,144 @@
+r"""The workitem stage timeline has to follow the theme, not paint its own white.
+
+Regression guard for #326. The stepper circles carried `background: #fff`
+written straight in, with no dark counterpart, so on a dark page the running
+stage rendered as a white disc. It was the worst possible glyph for it:
+`fa-circle-check` is a filled disc with the tick knocked *out*, so the white
+showed through the tick and the whole thing read as a bright bullseye -- the
+loudest element on an otherwise dark row. Nothing failed; the page returned
+200 and simply looked wrong.
+
+The invariants are about *where the colour comes from*, not what it looks
+like. A surface that sits on the themed panel must take its colour from a
+token, because a token is the only thing that has a dark value. Two `#fff`
+uses in the same block are legitimate and are named here so the test does not
+quietly start passing for the wrong reason:
+
+  - `.is-done { color: #fff }` -- an icon on the accent fill, white in both
+    themes by design.
+  - the document surfaces (`.src-thumb`, `.wi-doc-thumb`, `.wi-doc-full__page`)
+    -- those are scanned pages, and paper is white in the dark too.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CSS = REPO / "static" / "css"
+
+SHEET = CSS / "workitems_overview.css"
+SHARED = CSS / "nexora-ui.css"
+
+# Selectors that sit on the themed panel and therefore must not hardcode a
+# background. Every one of these was a white blob in dark mode before #326.
+THEMED_SURFACES = (
+    ".wi-stepper__icon",
+    ".wi-stepper__icon.is-current",
+    ".wi-doc-fullbtn",
+    ".wi-show-sources-btn",
+)
+
+# The document column renders page images. A scanned page is white paper in
+# both themes, so these keep their literal white on purpose.
+PAPER_SURFACES = (".src-thumb", ".wi-doc-thumb", ".wi-doc-full__page")
+
+WHITE = re.compile(r"#fff(?:fff)?\b|\bwhite\b", re.IGNORECASE)
+
+
+def _rules(path: Path):
+    """(selector, body) for every rule in the sheet, comments stripped."""
+    src = re.sub(r"/\*.*?\*/", "", path.read_text(encoding="utf-8"), flags=re.S)
+    return [(m.group(1).strip(), m.group(2)) for m in re.finditer(r"([^{}]+)\{([^{}]*)\}", src)]
+
+
+def _declarations_for(selector: str):
+    """Bodies of rules whose selector list contains exactly this selector."""
+    out = []
+    for sel, body in _rules(SHEET):
+        parts = [p.strip() for p in sel.split(",")]
+        if selector in parts:
+            out.append(body)
+    return out
+
+
+def _background_of(body: str) -> str:
+    hits = re.findall(r"(?:^|;)\s*background(?:-color)?\s*:\s*([^;]+)", body)
+    return hits[-1].strip() if hits else ""
+
+
+def test_the_stepper_block_still_exists():
+    """If the stepper is renamed or removed, the rest of this file is vacuous
+    and would pass while guarding nothing."""
+    assert SHEET.exists()
+    selectors = {sel for sel, _ in _rules(SHEET)}
+    flat = " ".join(selectors)
+    for name in THEMED_SURFACES:
+        assert name in flat, f"{name} is gone -- retarget or delete this guard"
+
+
+def test_themed_surfaces_take_their_background_from_a_token():
+    """A hardcoded background has no dark value, which is the whole bug."""
+    for selector in THEMED_SURFACES:
+        bodies = _declarations_for(selector)
+        assert bodies, f"no rule declares {selector}"
+        backgrounds = [_background_of(b) for b in bodies if _background_of(b)]
+        assert backgrounds, f"{selector} declares no background at all"
+        for value in backgrounds:
+            assert "var(--nx-" in value, (
+                f"{selector} has background {value!r} -- must be a token, or it "
+                f"cannot follow the theme (#326)"
+            )
+            assert not WHITE.search(
+                value
+            ), f"{selector} still resolves to a literal white: {value!r}"
+
+
+def test_pending_stage_label_is_a_token_not_a_grey_literal():
+    """`#c2c7cf` was ~1.6:1 on white -- unreadable in light mode and wrong in
+    dark. The colour has to come from the text scale."""
+    bodies = _declarations_for(".wi-stepper__label")
+    assert bodies
+    for body in bodies:
+        colors = re.findall(r"(?:^|;)\s*color\s*:\s*([^;]+)", body)
+        assert colors, ".wi-stepper__label declares no colour"
+        for value in colors:
+            assert (
+                "var(--nx-" in value
+            ), f".wi-stepper__label colour {value!r} must be a token (#326)"
+
+
+def test_the_card_token_actually_has_a_dark_value():
+    """The fix only works because --nx-card is redefined under html.dark. If
+    that block ever loses the token, every surface above silently goes back to
+    rendering light on a dark page."""
+    src = SHARED.read_text(encoding="utf-8")
+    dark = src.split("html.dark", 1)
+    assert len(dark) == 2, "nexora-ui.css has no html.dark block"
+    block = dark[1].split("}", 1)[0]
+    for token in ("--nx-card:", "--nx-text-meta:"):
+        assert token in block, f"{token} is not redefined for dark mode"
+
+
+def test_document_surfaces_keep_their_white_on_purpose():
+    """Guard against an over-eager sweep: these are page images, and paper is
+    white in both themes. If someone tokenises them, scans get a dark backing
+    and the page content stops reading as a document."""
+    for selector in PAPER_SURFACES:
+        bodies = [b for sel, b in _rules(SHEET) if selector in sel]
+        assert bodies, f"{selector} is gone -- update this guard"
+        assert any(WHITE.search(_background_of(b)) for b in bodies), (
+            f"{selector} no longer has a white background; page images are "
+            f"meant to look like paper in both themes"
+        )
+
+
+def test_the_done_icon_keeps_its_white_glyph():
+    """`.is-done` puts the icon on the accent fill, where white is correct in
+    both themes -- it is a foreground colour, not a surface."""
+    bodies = _declarations_for(".wi-stepper__icon.is-done")
+    assert bodies
+    assert any(
+        WHITE.search(m)
+        for body in bodies
+        for m in re.findall(r"(?:^|;)\s*color\s*:\s*([^;]+)", body)
+    ), ".is-done lost its white icon colour"


### PR DESCRIPTION
Closes #326.

The stage timeline in an expanded workitem row was painting white circles on
the dark panel. The running stage was the obvious one, because its icon is
`fa-circle-check` -- a filled disc with the tick knocked *out* -- so the white
showed through the tick and the node read as a bright bullseye, the loudest
thing on an otherwise dark row.

### What changed

`static/css/workitems_overview.css`, four surfaces off `#fff` and onto
`var(--nx-card)`:

| selector | what it is |
|---|---|
| `.wi-stepper__icon` | the not-yet-started stage circles |
| `.wi-stepper__icon.is-current` | the running stage's circle |
| `.wi-doc-fullbtn` | "Full view", above the document column |
| `.wi-show-sources-btn` | "Show sources", same row |

Plus `.wi-stepper__label` from a hardcoded `#c2c7cf` to `var(--nx-text-meta)`.
The old grey was around 1.6:1 against white, so it was barely legible in light
mode either.

`--nx-card` is `#ffffff` in light and `#1e293b` in dark, so **light mode does
not move at all** -- I checked the computed values both ways.

### Deliberately left white

- `.src-thumb`, `.wi-doc-thumb`, `.wi-doc-full__page` -- these are the document
  page images. A scan is paper, and paper is white in the dark too.
- `color: #fff` on `.is-done` -- a foreground colour on the accent fill, correct
  in both themes.

`tests/unit/test_workitem_stepper_styles.py` names both groups, so a later
"tokenise all the things" sweep can't quietly turn document scans grey.

### Verification

I reproduced it on a harness page loading the real stylesheets, then confirmed
the fix and confirmed light mode was unchanged. I also checked the guard
actually bites: putting `#fff` back on `.is-current` fails
`test_themed_surfaces_take_their_background_from_a_token` with the selector and
the offending value in the message. It passes on the fix.

### Reach

The stylesheet is shared, so this also lands on the generali pages,
`prepared_documents.html` and `reporting.html` wherever the panel renders.
