### PR TITLE
fix(env-sync): only flag a missing key the code does not default (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,24 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   old copy still writes — see `scripts/generali-import/README.md`.
 
 ### Fixed
+- **env-sync's ACTION NEEDED no longer cries wolf** (#313) — the headline
+  alarm fired on 11 keys absent from `env/PROD.env` on the server, and all 11
+  were false positives: each has a code default identical to the value
+  `env/PROD.env.example` ships, so its absence changes nothing. An alarm that
+  is wrong every time trains people to skim it, and it already cost something
+  — during #297 those keys were written up as real drift and the note had to
+  be retracted, while the actual fault sat in the quiet bucket. The script now
+  reads the repo's own `os.environ.get` / `os.getenv` defaults with `ast` and
+  splits the finding three ways: no default in code stays **actionable** and
+  sets the exit code (the `SUPPORT_MAIL`/#166 case it was built for); a default
+  equal to the example is reported quietly; a default that *contradicts* the
+  example is its own warning, because the server then runs on a value the repo
+  does not advertise. Defaults that point at another key (`MS02_STATS_DB_PORT`
+  inherits `MS02_DB_PORT`) resolve against the server file first, so setting
+  the base key on PROD gives the right answer rather than the source literal.
+  A key is only treated as defaulted when *every* read site supplies one, so
+  the scan can never silence a key that some call path still needs. Today's
+  run is exit 0 with all 11 in the quiet bucket.
 - **Workitem stage timeline no longer paints white circles in dark mode**
   (#326) — the stepper inside an expanded workitem row had `background: #fff`
   written into three surfaces with no dark counterpart: the not-yet-started

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Mark strings `{{ _('...') }}` in templates, `_('...')` / `gettext(...)` in Pytho
 
 `env/{INT,PROD,STAGING,TEST}.env` hold live credentials (DB, Graph, Octo, Flask secret key). They are **gitignored** and live only on dev and prod machines. Never paste their contents into chats, issues, or external tools; never add secret values to code or commit messages.
 
-Because they are gitignored, `deploy.yml` never copies them — **adding a key to `env/PROD.env.example` does nothing on the server until someone hand-edits `\\syapp01\d$\sydoc\nexora\env\PROD.env`**, and forgetting is silent. Run `scripts/env-sync.py` by hand once per deploy that touched an env key; it diffs the committed `.example` against the local and SYAPP01 copies and prints copy-pasteable lines for anything missing. Only a *missing* key is actionable — differing values are expected (dev ≠ PROD).
+Because they are gitignored, `deploy.yml` never copies them — **adding a key to `env/PROD.env.example` does nothing on the server until someone hand-edits `\\syapp01\d$\sydoc\nexora\env\PROD.env`**, and forgetting is silent. Run `scripts/env-sync.py` by hand once per deploy that touched an env key; it diffs the committed `.example` against the local and SYAPP01 copies and prints copy-pasteable lines for anything missing. Only a missing key that the code does **not** already default is actionable; a key whose code default matches the example is reported quietly, and differing values are expected (dev ≠ PROD).
 
 ## Working with Claude Code
 

--- a/scripts/env-sync.py
+++ b/scripts/env-sync.py
@@ -20,8 +20,16 @@ after. It is deliberately not automated and not a hook: it reports, you decide.
 
 What it will and will not complain about:
 
-* A key the example declares but the server lacks is **actionable** and sets the
-  exit code. That is a shape problem, and the answer is always "add the key".
+* A key the example declares but the server lacks is **actionable** -- but only
+  when the code has no default for it. That is the `SUPPORT_MAIL` shape, and
+  the answer is "add the key". If the code *does* default the key, its absence
+  changes nothing, so it is reported quietly instead (issue #313: this alarm
+  once fired 11 times and was wrong 11 times, which is how you teach people to
+  skim past it). Defaults are read out of the source with `ast`, not guessed
+  -- see `code_defaults()`.
+* A key the code defaults to something **other** than what the example ships is
+  its own warning: the server is silently running on a value the repo does not
+  advertise. Fix goes either direction -- set the key, or correct the example.
 * A key set on both sides with **different values** is only ever informational.
   Dev and PROD hold different credentials and endpoints, and PROD legitimately
   lags dev until the matching deploy lands, so failing on that would cry wolf
@@ -44,6 +52,8 @@ one, twice.
 """
 
 import argparse
+import ast
+import functools
 import hashlib
 import shutil
 import sys
@@ -77,6 +87,168 @@ def read_env(path):
     return dict(dotenv_values(path))
 
 
+# Python trees to scan for env defaults. Templates and generated SQL never read
+# the environment. tests/ is deliberately out: a default that only exists in a
+# fixture is not a default in production.
+CODE_ROOTS = ("nx_lib", "ops", "scripts")
+
+# Sentinel for "this read site supplied no default". None cannot double as the
+# marker, because `os.environ.get(k, None)` is a real (if pointless) default.
+NO_DEFAULT = object()
+
+
+def _literal(node):
+    """The constant a node evaluates to, or NO_DEFAULT if it is not constant."""
+    try:
+        value = ast.literal_eval(node)
+    except (ValueError, SyntaxError, TypeError):
+        return NO_DEFAULT
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    return NO_DEFAULT
+
+
+def _is_env_read(func):
+    """True for `os.environ.get(...)` / `os.getenv(...)`, whatever the alias."""
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr == "getenv":
+        return True
+    return (
+        func.attr == "get"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "environ"
+    )
+
+
+def _defaults_in_source(source, filename):
+    """key -> one entry per read site in this file.
+
+    Each entry is a literal, an ("alias", other_key) pair, or NO_DEFAULT.
+    Anything the scan cannot read exactly becomes NO_DEFAULT, which errs
+    toward calling a key actionable rather than waving it through.
+    """
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return {}
+
+    # `os.environ.get("K") or 120` -- the call passes no default but the
+    # surrounding expression supplies one. Collect those first, keyed by node.
+    or_defaults = {}
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.BoolOp) and isinstance(node.op, ast.Or)):
+            continue
+        if len(node.values) != 2:
+            continue
+        left, right = node.values
+        if isinstance(left, ast.Call) and _is_env_read(left.func):
+            fallback = _literal(right)
+            if fallback is not NO_DEFAULT:
+                or_defaults[id(left)] = fallback
+
+    # Module-level `NAME = os.environ.get("OTHER", ...)`, so that a default
+    # which is a bare Name can be followed: MS02_STATS_DB_PORT defaults to
+    # MS02_DB_PORT, which is itself an env read.
+    aliases = {}
+    for node in tree.body:
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1):
+            continue
+        target = node.targets[0]
+        value = node.value
+        if not isinstance(target, ast.Name):
+            continue
+        if isinstance(value, ast.Call) and _is_env_read(value.func) and value.args:
+            key = _literal(value.args[0])
+            if isinstance(key, str):
+                aliases[target.id] = key
+
+    found = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_env_read(node.func) and node.args:
+            key = _literal(node.args[0])
+            if not isinstance(key, str):
+                continue
+            if len(node.args) > 1:
+                arg = node.args[1]
+                if isinstance(arg, ast.Name) and arg.id in aliases:
+                    default = ("alias", aliases[arg.id])
+                else:
+                    default = _literal(arg)
+            else:
+                default = or_defaults.get(id(node), NO_DEFAULT)
+            found.setdefault(key, []).append(default)
+        elif isinstance(node, ast.Subscript) and isinstance(node.value, ast.Attribute):
+            # `os.environ["K"]` raises when the key is absent, so by
+            # definition it has no default.
+            if node.value.attr == "environ":
+                key = _literal(node.slice)
+                if isinstance(key, str):
+                    found.setdefault(key, []).append(NO_DEFAULT)
+    return found
+
+
+@functools.cache
+def code_defaults(repo_root=REPO_ROOT):
+    """Env key -> its code default, for keys that are defaulted *everywhere*.
+
+    A key read in two places, one of which passes no default, is not treated as
+    defaulted: that call site still gets None, so the key genuinely matters.
+    Two different literal defaults for one key are handled the same way --
+    ambiguous is not safe. Keys with no default never enter the result, which
+    is exactly what keeps them actionable.
+    """
+    per_key = {}
+    files = []
+    for name in CODE_ROOTS:
+        root = repo_root / name
+        if root.is_dir():
+            files += [p for p in sorted(root.rglob("*.py")) if "__pycache__" not in p.parts]
+    files += sorted(repo_root.glob("*.py"))
+
+    for path in files:
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for key, defaults in _defaults_in_source(source, str(path)).items():
+            per_key.setdefault(key, []).extend(defaults)
+
+    resolved = {}
+    for key, defaults in per_key.items():
+        if any(d is NO_DEFAULT for d in defaults):
+            continue
+        if len({repr(d) for d in defaults}) != 1:
+            continue
+        resolved[key] = defaults[0]
+    return resolved
+
+
+def resolve_default(key, defaults, remote, _seen=None):
+    """What the code falls back to for `key`, as the string env would hold.
+
+    An alias resolves against the server file first -- MS02_STATS_DB_PORT
+    inherits whatever MS02_DB_PORT actually is there -- and only then against
+    that key's own default. Pinning it to the literal instead would give the
+    wrong answer the moment someone sets the base key on the server.
+    """
+    seen = set() if _seen is None else _seen
+    if key in seen or key not in defaults:
+        return None
+    seen.add(key)
+
+    default = defaults[key]
+    if isinstance(default, tuple) and len(default) == 2 and default[0] == "alias":
+        target = default[1]
+        server_value = (remote or {}).get(target)
+        if server_value is not None:
+            return server_value
+        return resolve_default(target, defaults, remote, seen)
+    if default is None:
+        return None
+    return str(default)
+
+
 def _required(example, keys):
     """Split keys by whether the example ships a real default for them.
 
@@ -93,11 +265,14 @@ def _required(example, keys):
     return req, opt
 
 
-def diff_envs(example, local, remote):
+def diff_envs(example, local, remote, defaults=None):
     """Compare three key/value maps (any may be None for "file absent").
 
     Returns a dict of finding-name -> sorted keys. Kept pure so the interesting
-    logic is testable without a live SYAPP01 share.
+    logic is testable without a live SYAPP01 share -- `defaults` is passed in
+    (from `code_defaults()`) rather than scanned here, so this function still
+    touches no disk. Omit it and nothing is treated as defaulted, which is the
+    old behaviour.
     """
     ex = set(example or {})
     lo = set(local or {})
@@ -108,8 +283,25 @@ def diff_envs(example, local, remote):
     srv_req, srv_opt = _required(example, ex - re_) if remote is not None else ([], [])
     loc_req, loc_opt = _required(example, ex - lo) if local is not None else ([], [])
 
+    # ...except when the code defaults the key, in which case its absence from
+    # the server changes nothing and calling it ACTION NEEDED is a lie (#313).
+    defaults = defaults or {}
+    actionable, defaulted, mismatched = [], [], []
+    for key in srv_req:
+        if key not in defaults:
+            actionable.append(key)
+            continue
+        fallback = resolve_default(key, defaults, remote)
+        advertised = str((example or {}).get(key) or "")
+        if fallback is not None and fallback.strip() == advertised.strip():
+            defaulted.append(key)
+        else:
+            mismatched.append(key)
+
     return {
-        "missing_on_server": srv_req,
+        "missing_on_server": actionable,
+        "missing_on_server_defaulted": defaulted,
+        "missing_on_server_default_differs": mismatched,
         "missing_on_server_optional": srv_opt,
         "missing_locally": loc_req,
         "missing_locally_optional": loc_opt,
@@ -145,7 +337,8 @@ def report(name, show_values, verbose=False):
     if example is None:
         print(f"  note   : no committed {name}.example, cannot check for missing keys")
 
-    f = diff_envs(example, local, remote)
+    defaults = code_defaults()
+    f = diff_envs(example, local, remote, defaults)
 
     if f["missing_on_server"]:
         print(
@@ -159,6 +352,27 @@ def report(name, show_values, verbose=False):
             ex_val = str((example or {}).get(k) or "")
             shown = ex_val if len(ex_val) <= 60 else ex_val[:57] + "..."
             print(f"        {k}={shown}")
+    if f["missing_on_server_default_differs"]:
+        print(
+            f"  [!] {name}.example advertises a value the code does not fall back to "
+            f"({len(f['missing_on_server_default_differs'])}). The key is absent on\n"
+            f"      the server, so PROD runs on the code default, not on what the repo\n"
+            f"      says. Fix either side -- add the key, or correct the example:"
+        )
+        for k in f["missing_on_server_default_differs"]:
+            ex_val = str((example or {}).get(k) or "")
+            actual = resolve_default(k, defaults, remote)
+            print(f"        {k:<28} example={ex_val!r}  code falls back to={actual!r}")
+    if f["missing_on_server_defaulted"]:
+        print(
+            f"  [ ] {len(f['missing_on_server_defaulted'])} key(s) absent on server but "
+            f"defaulted in code to exactly what the example ships -- nothing to do"
+            f"{'' if verbose else ' (--verbose to list)'}:"
+        )
+        if verbose:
+            for k in f["missing_on_server_defaulted"]:
+                actual = resolve_default(k, defaults, remote)
+                print(f"        {k:<28} code default={actual!r}")
     if f["missing_on_server_optional"] and verbose:
         print(
             f"  [ ] opt-in keys (blank in {name}.example) absent on server "
@@ -201,9 +415,13 @@ def report(name, show_values, verbose=False):
     # PROD deliberately lags dev until its deploy lands -- so failing on that
     # would cry wolf on every run and stop the script being worth running. The
     # shape of the file is checkable; whether a value is right is a human call.
-    drift = bool(f["missing_on_server"])
+    # A defaulted key is deliberately *not* drift: the server behaves exactly as
+    # the repo describes without it, so failing on it is the cry-wolf that made
+    # this alarm worthless (#313). A key whose code default contradicts the
+    # example is drift, because somebody has to reconcile the two.
+    drift = bool(f["missing_on_server"] or f["missing_on_server_default_differs"])
     if not drift and local is not None and remote is not None:
-        print("  no missing keys")
+        print("  no keys missing that the code does not already default")
     return drift
 
 
@@ -276,15 +494,18 @@ def main():
 
     print()
     if drift:
-        print("Keys are missing on the server (see ACTION NEEDED above).")
+        print("Keys are missing on the server that the code does not default,")
+        print("or default to something the example contradicts (see above).")
         print("Best fix is pasting those lines into the server file by hand: pushing")
         print("the whole file also overwrites server-only values and any PROD setting")
         print("that is deliberately different from dev. If you do want the whole file:")
         print("  python scripts/env-sync.py --push PROD.env   # local  -> server")
         print("  python scripts/env-sync.py --pull PROD.env   # server -> local")
         return 1
-    print("No keys missing on the server. Any [~] value differences above are")
-    print("informational -- dev and PROD are expected to diverge.")
+    print("Nothing actionable. Any [~] value differences above are informational")
+    print("-- dev and PROD are expected to diverge -- and any key listed as")
+    print("defaulted in code is absent on the server on purpose: it behaves")
+    print("identically either way.")
     return 0
 
 

--- a/tests/unit/test_env_sync.py
+++ b/tests/unit/test_env_sync.py
@@ -2,6 +2,13 @@
 
 The point of the script is catching a key that the repo declares but the server
 never got (the SUPPORT_MAIL / issue #166 case), so that is what these pin down.
+
+The second half is about *not* crying wolf (#313). The same alarm used to fire
+on 11 keys that all had a code default equal to what the example ships, so
+their absence from the server changed nothing. An alarm wrong 11 times out of
+11 gets skimmed past, and then the real one is missed too -- which is what
+happened while diagnosing #297. So the classification, and the conservative
+rules behind it, are pinned here.
 """
 
 import importlib.util
@@ -103,3 +110,221 @@ def test_read_env_parses_a_real_file(env_sync, tmp_path):
     p = tmp_path / "x.env"
     p.write_text("# comment\nA=1\nB=two words\n", encoding="utf-8")
     assert env_sync.read_env(p) == {"A": "1", "B": "two words"}
+
+
+# --------------------------------------------------------------------------
+# #313: a missing key only matters when the code has no default for it.
+# --------------------------------------------------------------------------
+
+
+def test_missing_key_with_no_code_default_is_still_actionable(env_sync):
+    """The SUPPORT_MAIL case must survive the fix -- this is the whole point of
+    the script, and #313 only narrows what counts, never widens it."""
+    f = env_sync.diff_envs(
+        example={"SUPPORT_MAIL": "support@sydoc.ch"},
+        local={"SUPPORT_MAIL": "support@sydoc.ch"},
+        remote={},
+        defaults={"OUTAGE_SITE_URL": "https://x/"},
+    )
+    assert f["missing_on_server"] == ["SUPPORT_MAIL"]
+    assert f["missing_on_server_defaulted"] == []
+
+
+def test_missing_key_defaulted_to_the_example_value_is_not_actionable(env_sync):
+    """The 11 false positives. The server behaves identically without the key,
+    so calling it ACTION NEEDED is simply untrue."""
+    f = env_sync.diff_envs(
+        example={"OUTAGE_SITE_URL": "https://nexora.sydoc.ch/nexora/"},
+        local={},
+        remote={},
+        defaults={"OUTAGE_SITE_URL": "https://nexora.sydoc.ch/nexora/"},
+    )
+    assert f["missing_on_server"] == []
+    assert f["missing_on_server_defaulted"] == ["OUTAGE_SITE_URL"]
+    assert f["missing_on_server_default_differs"] == []
+
+
+def test_a_default_that_contradicts_the_example_is_its_own_warning(env_sync):
+    """Not noise: PROD runs on the code default while the repo advertises
+    something else. Someone has to reconcile the two."""
+    f = env_sync.diff_envs(
+        example={"AI_TIMEOUT_S": "120"},
+        local={},
+        remote={},
+        defaults={"AI_TIMEOUT_S": 90},
+    )
+    assert f["missing_on_server"] == []
+    assert f["missing_on_server_defaulted"] == []
+    assert f["missing_on_server_default_differs"] == ["AI_TIMEOUT_S"]
+
+
+def test_numeric_and_string_defaults_compare_equal(env_sync):
+    """`AI_AGENT_BUDGET_S` defaults to the int 180; the example ships the text
+    "180". Those are the same setting and must not be reported as a conflict."""
+    f = env_sync.diff_envs(
+        example={"AI_AGENT_BUDGET_S": "180"},
+        local={},
+        remote={},
+        defaults={"AI_AGENT_BUDGET_S": 180},
+    )
+    assert f["missing_on_server_defaulted"] == ["AI_AGENT_BUDGET_S"]
+
+
+def test_omitting_defaults_keeps_the_old_behaviour(env_sync):
+    """Callers that pass no defaults get exactly what they got before, so the
+    pure function stays usable without a repo to scan."""
+    f = env_sync.diff_envs(example={"OUTAGE_SITE_URL": "https://x/"}, local={}, remote={})
+    assert f["missing_on_server"] == ["OUTAGE_SITE_URL"]
+
+
+# --------------------------------------------------------------------------
+# Alias defaults: MS02_STATS_DB_PORT falls back to MS02_DB_PORT.
+# --------------------------------------------------------------------------
+
+
+def test_alias_default_follows_the_base_keys_own_default(env_sync):
+    defaults = {
+        "MS02_STATS_DB_PORT": ("alias", "MS02_DB_PORT"),
+        "MS02_DB_PORT": "5432",
+    }
+    assert env_sync.resolve_default("MS02_STATS_DB_PORT", defaults, {}) == "5432"
+
+
+def test_alias_default_prefers_what_the_server_actually_sets(env_sync):
+    """Resolving to the literal would be wrong the moment somebody sets the base
+    key on the server: the derived key inherits *that*, not the source default.
+    """
+    defaults = {
+        "MS02_STATS_DB_PORT": ("alias", "MS02_DB_PORT"),
+        "MS02_DB_PORT": "5432",
+    }
+    resolved = env_sync.resolve_default("MS02_STATS_DB_PORT", defaults, {"MS02_DB_PORT": "6000"})
+    assert resolved == "6000"
+
+
+def test_alias_cycle_terminates(env_sync):
+    """Defensive: a mutual fallback must not hang the script."""
+    defaults = {"A": ("alias", "B"), "B": ("alias", "A")}
+    assert env_sync.resolve_default("A", defaults, {}) is None
+
+
+# --------------------------------------------------------------------------
+# The source scan itself. Reading this wrong in the permissive direction would
+# silence a real alarm, so the conservative cases matter most.
+# --------------------------------------------------------------------------
+
+
+def test_scan_reads_a_plain_default(env_sync):
+    found = env_sync._defaults_in_source('import os\nX = os.environ.get("K", "v")\n', "t.py")
+    assert found["K"] == ["v"]
+
+
+def test_scan_reads_the_or_idiom(env_sync):
+    """`os.environ.get("K") or 120` passes no default argument but plainly has
+    one -- three of the eleven keys are written this way."""
+    found = env_sync._defaults_in_source('import os\nX = int(os.environ.get("K") or 120)\n', "t.py")
+    assert found["K"] == [120]
+
+
+def test_scan_treats_a_bare_read_as_having_no_default(env_sync):
+    found = env_sync._defaults_in_source('import os\nX = os.environ.get("K")\n', "t.py")
+    assert found["K"] == [env_sync.NO_DEFAULT]
+
+
+def test_scan_treats_subscript_access_as_having_no_default(env_sync):
+    """`os.environ["K"]` raises when the key is absent, so the key is required
+    by definition."""
+    found = env_sync._defaults_in_source('import os\nX = os.environ["K"]\n', "t.py")
+    assert found["K"] == [env_sync.NO_DEFAULT]
+
+
+def test_scan_handles_getenv_too(env_sync):
+    found = env_sync._defaults_in_source('import os\nX = os.getenv("K", "v")\n', "t.py")
+    assert found["K"] == ["v"]
+
+
+def test_a_key_read_once_without_a_default_is_not_defaulted(env_sync, tmp_path):
+    """The conservative rule. One call site passing no default still gets None,
+    so the key genuinely matters even though another site defaults it. Getting
+    this backwards would silence a real missing-key bug."""
+    (tmp_path / "nx_lib").mkdir()
+    (tmp_path / "nx_lib" / "a.py").write_text(
+        'import os\nX = os.environ.get("K", "v")\n', encoding="utf-8"
+    )
+    (tmp_path / "nx_lib" / "b.py").write_text(
+        'import os\nY = os.environ.get("K")\n', encoding="utf-8"
+    )
+    assert "K" not in env_sync.code_defaults(tmp_path)
+
+
+def test_conflicting_defaults_are_not_treated_as_defaulted(env_sync, tmp_path):
+    """Two different fallbacks for one key means the effective value depends on
+    which module ran -- ambiguous is not safe to wave through."""
+    (tmp_path / "nx_lib").mkdir()
+    (tmp_path / "nx_lib" / "a.py").write_text(
+        'import os\nX = os.environ.get("K", "one")\n', encoding="utf-8"
+    )
+    (tmp_path / "nx_lib" / "b.py").write_text(
+        'import os\nY = os.environ.get("K", "two")\n', encoding="utf-8"
+    )
+    assert "K" not in env_sync.code_defaults(tmp_path)
+
+
+def test_a_file_that_does_not_parse_does_not_break_the_scan(env_sync, tmp_path):
+    (tmp_path / "nx_lib").mkdir()
+    (tmp_path / "nx_lib" / "broken.py").write_text("def (:\n", encoding="utf-8")
+    (tmp_path / "nx_lib" / "ok.py").write_text(
+        'import os\nX = os.environ.get("K", "v")\n', encoding="utf-8"
+    )
+    assert env_sync.code_defaults(tmp_path)["K"] == "v"
+
+
+# --------------------------------------------------------------------------
+# Against the real repository -- the claim the issue actually makes.
+# --------------------------------------------------------------------------
+
+# Every key #313 listed, with the value env/PROD.env.example ships for it.
+ELEVEN_FALSE_POSITIVES = (
+    "AI_AGENT_BUDGET_S",
+    "AI_DAILY_LIMIT",
+    "AI_TIMEOUT_S",
+    "AZURE_OPENAI_API_VERSION",
+    "DB_ODBC_DRIVER",
+    "MS02_DB_PORT",
+    "MS02_DB_SSLMODE",
+    "MS02_DOCFIELDS_DB_PORT",
+    "MS02_STATS_DB_NAME",
+    "MS02_STATS_DB_PORT",
+    "OUTAGE_SITE_URL",
+)
+
+
+def test_every_key_the_issue_listed_is_detected_as_defaulted(env_sync):
+    """If a scan regression drops one of these, the false alarm comes straight
+    back -- and silently, because the output merely gets louder again."""
+    defaults = env_sync.code_defaults()
+    missing = [k for k in ELEVEN_FALSE_POSITIVES if k not in defaults]
+    assert not missing, f"no code default found for {missing}"
+
+
+def test_the_detected_defaults_match_what_the_example_ships(env_sync):
+    """The classification only lands in the quiet bucket when the two agree, so
+    pin the agreement rather than trusting the bucket."""
+    example = env_sync.read_env(env_sync.LOCAL_ENV_DIR / "PROD.env.example")
+    assert example, "env/PROD.env.example is missing"
+    defaults = env_sync.code_defaults()
+    for key in ELEVEN_FALSE_POSITIVES:
+        resolved = env_sync.resolve_default(key, defaults, {})
+        assert resolved is not None, f"{key} resolved to nothing"
+        assert resolved.strip() == str(example.get(key) or "").strip(), (
+            f"{key}: code falls back to {resolved!r} but the example ships "
+            f"{example.get(key)!r} -- one of the two has drifted"
+        )
+
+
+def test_keys_that_carry_real_credentials_are_never_defaulted(env_sync):
+    """A secret must never look defaulted, or its absence stops being reported.
+    These are exactly the keys whose absence breaks production silently."""
+    defaults = env_sync.code_defaults()
+    for key in ("DB_UID", "DB_PWD", "FLASK_SECRET_KEY", "SUPPORT_MAIL"):
+        assert key not in defaults, f"{key} looks defaulted -- it must stay actionable"


### PR DESCRIPTION
Closes #313.

The loud alarm was wrong every single time. All 11 keys it reported as missing
from the server have a code default identical to what `env/PROD.env.example`
ships, so their absence changes nothing. That is worse than useless: it trains
everyone to skim the one line that matters, and it already cost us once — during
#297 I wrote those keys up as real drift and had to retract it, while the actual
fault (a wrong `DB_REPORTING_GENERALI_RO_PWD`) sat quietly in the informational
bucket.

### How it decides now

env-sync reads the repo's own `os.environ.get` / `os.getenv` defaults with `ast`
and splits the missing-key finding three ways:

| what the code does | verdict | exit code |
|---|---|---|
| no default anywhere | **actionable** — add the key | non-zero |
| defaults to exactly what the example ships | quiet, nothing to do | 0 |
| defaults to something else | **warning** — PROD runs on a value the repo doesn't advertise | non-zero |

The third bucket is empty today. It exists because "the key is missing *and* the
example is lying about the fallback" is a genuine thing to reconcile, in either
direction.

### Why `ast` and not a regex

I surveyed every env read in `nx_lib/`, `ops/` and `scripts/` — 99 of them — and
there are exactly two default shapes:

- a literal: `os.environ.get("DB_ODBC_DRIVER", "SQL Server")`, and the
  `os.environ.get("AI_TIMEOUT_S") or 120` idiom
- a bare name pointing at another module-level env read:
  `os.environ.get("MS02_STATS_DB_PORT", MS02_DB_PORT)`

Zero other shapes, so the scan is exact rather than approximate. The second case
resolves against the **server file first**: if someone sets `MS02_DB_PORT=6000`
on PROD then `MS02_STATS_DB_PORT` inherits 6000, and reporting the source
literal 5432 would be wrong. env-sync already reads the server file, so this
costs nothing.

### Deliberately conservative

Being too permissive here would silence a real missing-key bug, which is much
worse than the noise being fixed. So:

- a key counts as defaulted only when **every** read site supplies a default —
  one bare `os.environ.get("K")` somewhere means that call path still gets
  `None`, so the key genuinely matters
- two different literal defaults for one key don't count either; ambiguous is
  not safe
- anything the scan can't read exactly is treated as "no default", i.e.
  actionable
- a file that doesn't parse is skipped, not fatal

`test_keys_that_carry_real_credentials_are_never_defaulted` pins `DB_UID`,
`DB_PWD`, `FLASK_SECRET_KEY` and `SUPPORT_MAIL` as never-defaulted, since those
are exactly the keys whose absence breaks production silently.

### Verification

Real run against SYAPP01, before and after:

- **before** — `[!] ACTION NEEDED ... (11)`, exit 1
- **after** — `[ ] 11 key(s) absent on server but defaulted in code to exactly
  what the example ships -- nothing to do`, exit 0

`--verbose` lists them with the resolved default, so you can see *why* each one
is fine. Nothing else in the output moved: the local-only keys, the 3 value
differences and the undeclared `BEXIO_PAT` all still report as before.

I also mutation-checked the guard: making the scan permissive (dropping the
"every read site" rule) makes the credentials test fail, so these tests bite
rather than just pass.

19 new tests, 31 in the file, full unit tier green (1804).

### Still open, not in here

Two things the issue noted in passing, both left alone on purpose:

- `AI_DAILY_LIMIT` defaults to `0`, which the code documents as unlimited — so
  there's no per-user daily cap on AI asks in production. Worth being a decision
  rather than an accident, but that's a policy call, not a bug.
- `MS02_STATS_DB_NAME` defaults to `"Praesidialdepartement_BS"` — one customer's
  database name as the fallback in shared code, on a product that onboards
  tenants.
