### PR TITLE
feat(reporting): register the Elektro-Material billing source (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Elektro-Material — Verrechnung reporting source** (#329) — migration
+  `0130` registers `SYDOC_Statistik.dbo.EM_Invoice`, the table the monthly
+  `EM-Statistik<YYYYMM>.xlsx` workbook on the R: drive already reads, so the
+  billing figures stop depending on somebody refreshing a 140 MB spreadsheet and
+  ticking the right export timestamps out of a filter list. Five measures, taken
+  from that workbook's own pivot definition: documents (Opex + e-mail), Opex
+  scans, e-mail documents, order item positions and images out. Checked against
+  six published months — Opex scans and order positions reproduce exactly in
+  four of them, worst deviation 1.06%, and every difference is negative because
+  re-running a past month returns fewer rows than the workbook captured at the
+  time. Every measure filters to the two billed intake channels, since the table
+  also holds `Nexora` and NULL rows the workbook never counted; the amount, IBAN
+  and creditor columns are left out of the catalogue because billing scan volume
+  does not need them.
 - **Aveniq — Xpert Statistics reporting source** — migration `0128` registers
   `SYDOC_Statistik.dbo.Xpert_Stats` (daily DPSI counts pushed by mail from the
   Aveniq box, see `nx-sources/xpert/`) as a `table` source with three measures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Privera physische Zustellung reporting source, and cross-database sources**
+  (#329) — migration `0133` registers
+  `01_Privera_Posteingang.dbo.Reporting_P1_Nachsendungen`, the first source
+  outside `SYDOC_Statistik`. Same server and login; what had to change is the
+  identifier guard in `nx_lib/reporting/table_query.py`, which refused any name
+  starting with a digit and so could not express `01_Privera_Posteingang` at
+  all. The allowed character set is unchanged — letters, digits and underscore
+  — so no name can still carry a `]` out of the bracket quoting; only the
+  leading-digit rule moved. Two measures, both exact against the published July
+  and August 2026 workbooks: forwardings total, and the workbook's hand-added
+  "ohne TEC" line, which excludes the `Rechnungen Privera TEC` forwarding type
+  — not the TEC branch, which is the plausible wrong guess and gives a
+  different figure.
 - **Compass Group and Privera billing reporting sources** (#329) — migrations
   `0131` and `0132`, following `0130`, register
   `SYDOC_Statistik.dbo.Compass_Invoice` and `dbo.PriveraInvoice`: the tables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Compass Group and Privera billing reporting sources** (#329) — migrations
+  `0131` and `0132`, following `0130`, register
+  `SYDOC_Statistik.dbo.Compass_Invoice` and `dbo.PriveraInvoice`: the tables
+  the monthly `CompassGroupVerrechnung<YYYYMM>.xlsx` and
+  `Privera-Invoice-Mandant-<YYYY>-<Monat>.xlsx` workbooks already read. Each
+  customer's pivot is a different shape and the differences matter. Compass
+  bills one unfiltered document count on the **upload** date, not the document
+  date its pivot rows display — documents uploaded in one month carry document
+  dates spread over years. Privera publishes three figures (total, mail,
+  eBill), split on `DocSource` instead of the workbook's list of ticked file
+  names. Verified against the published workbooks: Compass exact in six of
+  eight months (off by one document in the other two), Privera exact in five of
+  six figures — the exception is August 2026 mail, where the old pivot dropped
+  5 mail documents that have no `Mandant` while its own total counted them, so
+  the measure keeps the honest definition and `Mandant` stays a dimension for
+  anyone who wants the old behaviour. No billing source exposes amounts, IBANs,
+  creditor names or Privera's property and owner numbers.
 - **Elektro-Material — Verrechnung reporting source** (#329) — migration
   `0130` registers `SYDOC_Statistik.dbo.EM_Invoice`, the table the monthly
   `EM-Statistik<YYYYMM>.xlsx` workbook on the R: drive already reads, so the

--- a/docs/howto/reporting.md
+++ b/docs/howto/reporting.md
@@ -1293,7 +1293,26 @@ old pivot dropped 5 mail documents that have no `Mandant` while its own total
 counted them, so the measure keeps the honest definition and `Mandant` stays a
 dimension. `SortOrder` 340/350. Both pinned by
 `tests/unit/test_billing_sources.py`, which also asserts no billing source
-exposes amounts, IBANs or the Privera property/owner numbers. The wizard's measure step walks
+exposes amounts, IBANs or the Privera property/owner numbers. `0133` adds **Privera —
+Physische Zustellung** (`privera_nachsendungen`), the **first source outside
+`SYDOC_Statistik`**: its `BaseObject` is the three-part
+`01_Privera_Posteingang.dbo.Reporting_P1_Nachsendungen`. Same engine, same
+server, same login — but the identifier guard in `table_query.py` had to stop
+refusing a name that starts with a digit first (`^[A-Za-z_]…` → `^[A-Za-z0-9_]+$`;
+the character set is unchanged, so nothing can still carry a `]` out of the
+bracket quoting). Two measures, both verified exactly against July and August
+2026: `Forwardings total`, and `Forwardings without TEC`, which is the
+workbook's hand-added "ohne TEC" line — it excludes the `Rechnungen Privera TEC`
+**Nachsendungstyp**, not the TEC *Niederlassung*; the latter is the plausible
+wrong guess and gives a different number. `SortOrder` 360.
+
+The sibling **Posteingang** report (`Reporting_P1_Dokumente` in the same
+database) is **not** registered, and cannot be until the source database
+changes: its `ExportDatetime` is `nvarchar` holding `dd.MM.yyyy HH:mm:ss`, and
+our connection runs `us_english`, so grouping it by month parses `01.02.2021` as
+**2 January** and raises outright on any day past the 12th. It needs a real
+datetime column (the `ExportEM`/`ExportEM_dt` pattern) or a view using
+`TRY_CONVERT(..., 104)`. The wizard's measure step walks
 sources in `SortOrder` and splits a `Tenant — Thing` label at the em dash: one
 uppercase heading per tenant, a `.rs-choice-group-sublabel` per source. The
 tenant's lookup tables carry no measures and are not registered. Each source is gated by its own

--- a/docs/howto/reporting.md
+++ b/docs/howto/reporting.md
@@ -1277,7 +1277,23 @@ never charged for. `ExportEM_dt` is the grainable date, not the `ExportEM`
 nvarchar beside it. The amount, IBAN and creditor columns are deliberately left
 out of `ColumnsJSON`: billing scan volume does not need them, and a column that
 is not in the catalogue cannot be queried. `SortOrder` 330. Shape pinned by
-`tests/unit/test_em_invoice_source.py`. The wizard's measure step walks
+`tests/unit/test_em_invoice_source.py`. `0131` and `0132` add the next two
+billing sources from the same ticket, **Compass Group — Verrechnung**
+(`compass_invoice` over `dbo.Compass_Invoice`) and **Privera —
+Rechnungseingang** (`privera_invoice` over `dbo.PriveraInvoice`). Each
+customer's workbook turned out to be a different shape, and the differences are
+load-bearing: Compass's pivot has **no** channel split, so its single
+`Documents` measure is unfiltered and bills on `UploadDatetime` (the pivot's
+page filter) rather than the `DocDate` its rows display; Privera publishes three
+pivots, so it gets `Documents total` / `Documents by mail` / `eBill documents`,
+split on `DocSource` rather than the workbook's unreproducible `FileName`
+filter. Verified against the published workbooks: Compass exact in 6 of 8
+months, Privera exact in 5 of 6 figures — the gap is August 2026 mail, where the
+old pivot dropped 5 mail documents that have no `Mandant` while its own total
+counted them, so the measure keeps the honest definition and `Mandant` stays a
+dimension. `SortOrder` 340/350. Both pinned by
+`tests/unit/test_billing_sources.py`, which also asserts no billing source
+exposes amounts, IBANs or the Privera property/owner numbers. The wizard's measure step walks
 sources in `SortOrder` and splits a `Tenant — Thing` label at the em dash: one
 uppercase heading per tenant, a `.rs-choice-group-sublabel` per source. The
 tenant's lookup tables carry no measures and are not registered. Each source is gated by its own

--- a/docs/howto/reporting.md
+++ b/docs/howto/reporting.md
@@ -1263,7 +1263,21 @@ as dimensions). `0128` registers **Aveniq — Xpert Statistics** (`xpert_stats` 
 Aveniq box and loaded by `nx-sources/xpert/importCSVtoSQL.py`; every measure is a
 conditional `sum` of `Cnt` on `Metric` so subsets never double-count — `Documents`
 = `Total`, `BFH new creditors`, `ZHAW workitems`; `ExportDate` grainable, `Client`
-the natural dimension). `SortOrder` 320. The wizard's measure step walks
+the natural dimension). `SortOrder` 320. `0130` registers **Elektro-Material —
+Verrechnung** (`em_invoice` over `SYDOC_Statistik.dbo.EM_Invoice`, the table the
+monthly `EM-Statistik<YYYYMM>.xlsx` workbook already reads through Power Query;
+#329). Its measures are that workbook's own pivot, read out of the pivot
+definition rather than guessed: `Documents (Opex + e-mail)`, `Opex scans` and
+`E-mail documents` are conditional counts on `Eingang`, `Order item positions`
+and `Images out` conditional sums of `OrdItmPosCount`/`AnzImagesOut`. **Every**
+measure carries the `Eingang IN ('OPEX Scan Scanner','E_MAIL')` filter, because
+the workbook's total is the sum of its two rows while the table also holds
+`Nexora` and NULL rows -- an unfiltered sum would bill documents the customer was
+never charged for. `ExportEM_dt` is the grainable date, not the `ExportEM`
+nvarchar beside it. The amount, IBAN and creditor columns are deliberately left
+out of `ColumnsJSON`: billing scan volume does not need them, and a column that
+is not in the catalogue cannot be queried. `SortOrder` 330. Shape pinned by
+`tests/unit/test_em_invoice_source.py`. The wizard's measure step walks
 sources in `SortOrder` and splits a `Tenant — Thing` label at the em dash: one
 uppercase heading per tenant, a `.rs-choice-group-sublabel` per source. The
 tenant's lookup tables carry no measures and are not registered. Each source is gated by its own

--- a/nx_lib/reporting/table_query.py
+++ b/nx_lib/reporting/table_query.py
@@ -11,7 +11,12 @@ import re
 
 from .semantic import build_aggregate_sql
 
-_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# A leading digit is allowed because real databases have names like
+# `01_Privera_Posteingang` (#329). This only relaxes *where* a digit may
+# appear, never which characters are permitted: the set is still letters,
+# digits and underscore, so a name can carry no `]` to close the bracket
+# quoting in _quote_ident() early, and no whitespace, quote or semicolon.
+_IDENT = re.compile(r"^[A-Za-z0-9_]+$")
 
 _OP_SYMBOLS = {"eq": "=", "ne": "<>", "gt": ">", "gte": ">=", "lt": "<", "lte": "<="}
 

--- a/sql/_migrations/NexoraDB/0130_seed_em_invoice_source.sql
+++ b/sql/_migrations/NexoraDB/0130_seed_em_invoice_source.sql
@@ -1,0 +1,89 @@
+-- 0130_seed_em_invoice_source.sql
+-- Elektro-Material ZH monthly billing figures, from AES Sprint 54 (#329):
+-- replace the hand-refreshed workbook under
+-- R:\...\Elektro-Material_ZH\...\Statistik\Monatsauswertungen\EM-Statistik<YYYYMM>.xlsx
+-- with a reporting source over SYDOC_Statistik.dbo.EM_Invoice, which is what
+-- that workbook's Power Query already reads.
+--
+-- WHAT THE OLD REPORT ACTUALLY IS
+-- A single pivot: rows = Eingang, page filter = ExportEM, three data fields --
+-- "Anzahl von DocBarcode", "Summe von AnzImagesOut", "Summe von OrdItmPosCount".
+-- The measures below are those three plus the Opex/e-mail split the pivot shows
+-- as its two rows. Read out of the workbook's own pivot definition rather than
+-- guessed from the sheet.
+--
+-- WHY EVERY MEASURE CARRIES THE SAME Eingang FILTER
+-- The published total is the sum of the pivot's two rows, OPEX + E_MAIL. Over
+-- the whole table Eingang also takes 'Nexora' (3 rows) and NULL (286), so an
+-- unfiltered SUM would quietly bill rows the workbook never counted. The
+-- filter makes the totals mean "Opex + e-mail" in every month, including one
+-- where a stray channel appears. Conditional aggregation is the 0128 pattern.
+--
+-- WHY ExportEM_dt AND NOT ExportEM
+-- Both exist and agree where both are set, but ExportEM is nvarchar holding
+-- 'dd.mm.yyyy HH:MM:SS' -- unsortable, ungrainable, and the reason the old
+-- report needs a human to tick the right timestamps out of a filter list every
+-- month. ExportEM_dt is a real datetime and covers more rows.
+--
+-- THE AMOUNT COLUMNS ARE DELIBERATELY NOT EXPOSED
+-- EM_Invoice carries GrossAmount/NetAmount/VatAmount, BankIBAN, SPC_IBAN,
+-- CrdNO and creditor names. None of it is needed to bill scan volume, so it is
+-- left out of ColumnsJSON: a column that is not in the catalogue cannot be
+-- selected, filtered or sorted by anyone holding the permission.
+--
+-- Permission follows reporting.source.<code>.use (0088). Idempotent.
+
+INSERT INTO dbo.Permission (Code, Description)
+SELECT N'reporting.source.em_invoice.use', N'Use the Elektro-Material billing source'
+WHERE NOT EXISTS (SELECT 1 FROM dbo.Permission WHERE Code = N'reporting.source.em_invoice.use');
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.ReportingSources WHERE Code = 'em_invoice')
+INSERT INTO dbo.ReportingSources
+    (Code, Kind, Label, Permission, Engine, Provider, BaseObject, ColumnsJSON, Enabled, SortOrder)
+VALUES (
+    'em_invoice', 'curated', N'Elektro-Material — Verrechnung',
+    'reporting.source.em_invoice.use', 'statistics', 'table', 'dbo.EM_Invoice',
+    N'[{"field":"ExportEM_dt","label":"Export date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"Eingang","label":"Channel","type":"string","filterable":true,"sortable":true},
+       {"field":"DocBarcode","label":"Document barcode","type":"string","filterable":true,"sortable":true},
+       {"field":"DocType","label":"Document type","type":"string","filterable":true,"sortable":true},
+       {"field":"DocDate","label":"Document date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"OrdItmPosCount","label":"Order item positions","type":"number","filterable":true,"sortable":true},
+       {"field":"AnzImagesOut","label":"Images out","type":"number","filterable":true,"sortable":true},
+       {"field":"AnzImagesIn","label":"Images in","type":"number","filterable":true,"sortable":true},
+       {"field":"IsWithOrder","label":"With order","type":"string","filterable":true,"sortable":true},
+       {"field":"isExpress","label":"Express","type":"string","filterable":true,"sortable":true},
+       {"field":"Branch","label":"Branch","type":"string","filterable":true,"sortable":true},
+       {"field":"ScanUser","label":"Scan user","type":"string","filterable":true,"sortable":true},
+       {"field":"ValUser","label":"Validation user","type":"string","filterable":true,"sortable":true}]',
+    1, 330);
+GO
+
+INSERT INTO dbo.ReportingMetrics
+    (Code, SourceId, Label, GermanLabel, FrenchLabel, ItalianLabel, Aggregation, BaseField, FilterJson, Description, Format, SortOrder)
+SELECT v.Code, v.SourceId, v.Label, v.De, v.Fr, v.It, v.Agg, v.BaseField, v.Filt, v.Descr, v.Fmt, v.SortOrder
+FROM (VALUES
+    ('em_documents', 'em_invoice',
+        N'Documents (Opex + e-mail)', N'Dokumente (Opex + E-Mail)', N'Documents (Opex + e-mail)', N'Documenti (Opex + e-mail)',
+        'count', NULL, N'[{"field":"Eingang","op":"in","value":["OPEX Scan Scanner","E_MAIL"]}]',
+        N'Total document barcodes billed for the period, both intake channels. Matches the pivot''s Gesamtergebnis for "Anzahl von DocBarcode".', 'int', 330),
+    ('em_opex_scans', 'em_invoice',
+        N'Opex scans', N'Opex-Scans', N'Scans Opex', N'Scansioni Opex',
+        'count', NULL, N'[{"field":"Eingang","op":"eq","value":"OPEX Scan Scanner"}]',
+        N'Documents that came in on the Opex scanner rather than by e-mail.', 'int', 331),
+    ('em_email_documents', 'em_invoice',
+        N'E-mail documents', N'E-Mail-Dokumente', N'Documents par e-mail', N'Documenti via e-mail',
+        'count', NULL, N'[{"field":"Eingang","op":"eq","value":"E_MAIL"}]',
+        N'Documents that arrived by e-mail. The other half of the Opex/e-mail split.', 'int', 332),
+    ('em_order_positions', 'em_invoice',
+        N'Order item positions', N'Bestellpositionen', N'Postes de commande', N'Posizioni d''ordine',
+        'sum', 'OrdItmPosCount', N'[{"field":"Eingang","op":"in","value":["OPEX Scan Scanner","E_MAIL"]}]',
+        N'Sum of OrdItmPosCount over both channels -- the pivot''s "Summe von OrdItmPosCount".', 'int', 333),
+    ('em_images_out', 'em_invoice',
+        N'Images out', N'Ausgegebene Bilder', N'Images sorties', N'Immagini in uscita',
+        'sum', 'AnzImagesOut', N'[{"field":"Eingang","op":"in","value":["OPEX Scan Scanner","E_MAIL"]}]',
+        N'Sum of AnzImagesOut over both channels -- the pivot''s "Summe von AnzImagesOut".', 'int', 334)
+) AS v(Code, SourceId, Label, De, Fr, It, Agg, BaseField, Filt, Descr, Fmt, SortOrder)
+WHERE NOT EXISTS (SELECT 1 FROM dbo.ReportingMetrics m WHERE m.Code = v.Code);
+GO

--- a/sql/_migrations/NexoraDB/0131_seed_compass_invoice_source.sql
+++ b/sql/_migrations/NexoraDB/0131_seed_compass_invoice_source.sql
@@ -1,0 +1,73 @@
+-- 0131_seed_compass_invoice_source.sql
+-- Compass Group monthly billing figures, from AES Sprint 54 (#329), following
+-- 0130 (Elektro-Material). Replaces the hand-refreshed
+-- R:\...\CompassGroup\01_PosteingangKreditoren\Verrechnung\CompassGroupVerrechnung<YYYYMM>.xlsx
+-- with a source over SYDOC_Statistik.dbo.Compass_Invoice, which is what that
+-- workbook's Power Query already reads.
+--
+-- WHAT THE OLD REPORT IS
+-- One pivot, and a simpler one than Elektro-Material's: a single data field,
+-- "Anzahl von DocBarcode", with UploadDatetime as the page filter and DocDate
+-- (auto-grouped by Excel into Jahre/Quartale/month) as the rows. So the billed
+-- figure is a plain document count for the upload month; the DocDate breakdown
+-- is detail, not a second measure.
+--
+-- THE PERIOD IS UploadDatetime, NOT DocDate
+-- Worth stating because the pivot's rows are DocDate and that is the eye-catching
+-- part. Documents uploaded in one month carry document dates spread over years --
+-- the May 2026 workbook shows rows under 2022, 2024 and 2025, plus 235 with no
+-- usable DocDate at all. Counting by DocDate would bill a different set entirely.
+-- Verified: UploadDatetime in May 2026 gives exactly the published 9,185.
+--
+-- NO CHANNEL FILTER HERE, UNLIKE 0130
+-- Elektro-Material's measures all filter Eingang to the two billed channels,
+-- because its pivot totalled two channel rows. This pivot has no such split and
+-- its unfiltered count reproduces the published total exactly, so adding a filter
+-- "for consistency" with 0130 would change the number. Compass_Invoice does have
+-- an Eingang column; it stays a dimension, not a filter.
+--
+-- AMOUNT AND BANK COLUMNS ARE NOT EXPOSED
+-- Same call as 0130: GrossAmount/NetAmount/VatAmount, SPC_IBAN, BankPK, CrdNO,
+-- CRDNAME1 and InvoiceNR are not needed to bill document volume, so they are left
+-- out of ColumnsJSON and cannot be selected, filtered or sorted.
+--
+-- Permission follows reporting.source.<code>.use (0088). Idempotent.
+
+INSERT INTO dbo.Permission (Code, Description)
+SELECT N'reporting.source.compass_invoice.use', N'Use the Compass Group billing source'
+WHERE NOT EXISTS (SELECT 1 FROM dbo.Permission WHERE Code = N'reporting.source.compass_invoice.use');
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.ReportingSources WHERE Code = 'compass_invoice')
+INSERT INTO dbo.ReportingSources
+    (Code, Kind, Label, Permission, Engine, Provider, BaseObject, ColumnsJSON, Enabled, SortOrder)
+VALUES (
+    'compass_invoice', 'curated', N'Compass Group — Verrechnung',
+    'reporting.source.compass_invoice.use', 'statistics', 'table', 'dbo.Compass_Invoice',
+    N'[{"field":"UploadDatetime","label":"Upload date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"DocDate","label":"Document date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"ImportDate","label":"Import date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"ExportDate","label":"Export date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"DocBarcode","label":"Document barcode","type":"string","filterable":true,"sortable":true},
+       {"field":"DocType","label":"Document type","type":"string","filterable":true,"sortable":true},
+       {"field":"Mandat","label":"Mandate","type":"string","filterable":true,"sortable":true},
+       {"field":"Eingang","label":"Channel","type":"string","filterable":true,"sortable":true},
+       {"field":"IsWithOrder","label":"With order","type":"string","filterable":true,"sortable":true},
+       {"field":"Branch","label":"Branch","type":"string","filterable":true,"sortable":true},
+       {"field":"ScanUser","label":"Scan user","type":"string","filterable":true,"sortable":true},
+       {"field":"OrdItmPosCount","label":"Order item positions","type":"number","filterable":true,"sortable":true},
+       {"field":"AnzImagesOut","label":"Images out","type":"number","filterable":true,"sortable":true}]',
+    1, 340);
+GO
+
+INSERT INTO dbo.ReportingMetrics
+    (Code, SourceId, Label, GermanLabel, FrenchLabel, ItalianLabel, Aggregation, BaseField, FilterJson, Description, Format, SortOrder)
+SELECT v.Code, v.SourceId, v.Label, v.De, v.Fr, v.It, v.Agg, v.BaseField, v.Filt, v.Descr, v.Fmt, v.SortOrder
+FROM (VALUES
+    ('compass_documents', 'compass_invoice',
+        N'Documents', N'Dokumente', N'Documents', N'Documenti',
+        'count', NULL, NULL,
+        N'The billed figure: one per document barcode. Group by Upload date to get the month the Verrechnung invoices -- the workbook''s "Anzahl von DocBarcode".', 'int', 340)
+) AS v(Code, SourceId, Label, De, Fr, It, Agg, BaseField, Filt, Descr, Fmt, SortOrder)
+WHERE NOT EXISTS (SELECT 1 FROM dbo.ReportingMetrics m WHERE m.Code = v.Code);
+GO

--- a/sql/_migrations/NexoraDB/0132_seed_privera_invoice_source.sql
+++ b/sql/_migrations/NexoraDB/0132_seed_privera_invoice_source.sql
@@ -1,0 +1,84 @@
+-- 0132_seed_privera_invoice_source.sql
+-- Privera Rechnungseingang monthly billing figures, from AES Sprint 54 (#329),
+-- following 0130/0131. Replaces
+-- R:\...\Privera\01_Posteingang\Statistik\Privera-Invoice-Mandant-<YYYY>-<Monat>.xlsx
+-- with a source over SYDOC_Statistik.dbo.PriveraInvoice, the table that
+-- workbook's Power Query already reads.
+--
+-- WHAT THE OLD REPORT IS
+-- Three pivots, all counting Barcode by Mandant with ExportDate as the page
+-- filter, published as "PRIVERA Invoice gesamt", "... Mail" and "... eBill".
+-- Hence three measures rather than one.
+--
+-- HOW THE MAIL/eBILL SPLIT IS DONE HERE
+-- The workbook splits them with a FileName page filter -- a list of ticked file
+-- names, which is neither reproducible nor meaningful. DocSource carries the
+-- same classification as data: MAIL / SCANINVOICE / POSTEINGANG / eBill, and
+-- those four partition the month exactly (11,764 + 5,310 + 135 + 13 = 17,222 for
+-- August 2026). So the measures key on DocSource.
+--
+-- ONE KNOWN DIFFERENCE, DELIBERATELY NOT PAPERED OVER
+-- Verified against the published July and August 2026 workbooks: gesamt and
+-- eBill match exactly in both months, and Mail matches exactly in July. In
+-- August, DocSource='MAIL' gives 11,764 against a published 11,759. The five
+-- extra rows are MAIL documents with no Mandant, which the workbook's Mail pivot
+-- dropped while its gesamt pivot counted them (the 612 "(Leer)" row). That is an
+-- inconsistency in the old report, not a billing rule, so the measure here is the
+-- honest "arrived by mail" definition and Mandant stays a dimension -- anyone who
+-- wants the old behaviour can exclude the blanks, and it is one filter, not a
+-- silent rule welded into the metric. Flagged on #329 for invoicing to settle.
+--
+-- AMOUNT, BANK AND PROPERTY COLUMNS ARE NOT EXPOSED
+-- Same call as 0130/0131, and PriveraInvoice carries more than most: amounts,
+-- IBAN, ESR, creditor number and name, plus LiegenschaftsNr/EigentuemerNr, which
+-- identify a property and its owner. None of it is needed to bill document
+-- volume, so none of it is in ColumnsJSON.
+--
+-- Permission follows reporting.source.<code>.use (0088). Idempotent.
+
+INSERT INTO dbo.Permission (Code, Description)
+SELECT N'reporting.source.privera_invoice.use', N'Use the Privera Rechnungseingang billing source'
+WHERE NOT EXISTS (SELECT 1 FROM dbo.Permission WHERE Code = N'reporting.source.privera_invoice.use');
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.ReportingSources WHERE Code = 'privera_invoice')
+INSERT INTO dbo.ReportingSources
+    (Code, Kind, Label, Permission, Engine, Provider, BaseObject, ColumnsJSON, Enabled, SortOrder)
+VALUES (
+    'privera_invoice', 'curated', N'Privera — Rechnungseingang',
+    'reporting.source.privera_invoice.use', 'statistics', 'table', 'dbo.PriveraInvoice',
+    N'[{"field":"ExportDate","label":"Export date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"ScanTime","label":"Scan date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"ImportTime","label":"Import date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"Barcode","label":"Barcode","type":"string","filterable":true,"sortable":true},
+       {"field":"Mandant","label":"Mandant","type":"string","filterable":true,"sortable":true},
+       {"field":"DocSource","label":"Source","type":"string","filterable":true,"sortable":true},
+       {"field":"DocType","label":"Document type","type":"string","filterable":true,"sortable":true},
+       {"field":"Niederlassung","label":"Branch","type":"string","filterable":true,"sortable":true},
+       {"field":"IstwitOrder","label":"With order","type":"string","filterable":true,"sortable":true},
+       {"field":"ScanUser","label":"Scan user","type":"string","filterable":true,"sortable":true},
+       {"field":"ValUser","label":"Validation user","type":"string","filterable":true,"sortable":true},
+       {"field":"AnzImagesScanned","label":"Images scanned","type":"number","filterable":true,"sortable":true},
+       {"field":"Reason_no_Export","label":"Reason not exported","type":"string","filterable":true,"sortable":true}]',
+    1, 350);
+GO
+
+INSERT INTO dbo.ReportingMetrics
+    (Code, SourceId, Label, GermanLabel, FrenchLabel, ItalianLabel, Aggregation, BaseField, FilterJson, Description, Format, SortOrder)
+SELECT v.Code, v.SourceId, v.Label, v.De, v.Fr, v.It, v.Agg, v.BaseField, v.Filt, v.Descr, v.Fmt, v.SortOrder
+FROM (VALUES
+    ('privera_documents', 'privera_invoice',
+        N'Documents total', N'Dokumente gesamt', N'Documents au total', N'Documenti in totale',
+        'count', NULL, NULL,
+        N'Every invoice document exported in the period, whatever its source -- the workbook''s "PRIVERA Invoice gesamt". Group by Mandant to get its breakdown.', 'int', 350),
+    ('privera_mail_documents', 'privera_invoice',
+        N'Documents by mail', N'Dokumente per E-Mail', N'Documents par e-mail', N'Documenti via e-mail',
+        'count', NULL, N'[{"field":"DocSource","op":"eq","value":"MAIL"}]',
+        N'Documents that arrived by mail. The old workbook split this with a FileName filter and dropped mail documents that have no Mandant, so its August 2026 figure was 5 lower than this one.', 'int', 351),
+    ('privera_ebill_documents', 'privera_invoice',
+        N'eBill documents', N'eBill-Dokumente', N'Documents eBill', N'Documenti eBill',
+        'count', NULL, N'[{"field":"DocSource","op":"eq","value":"eBill"}]',
+        N'Documents received as eBill -- the workbook''s "PRIVERA Invoice eBill".', 'int', 352)
+) AS v(Code, SourceId, Label, De, Fr, It, Agg, BaseField, Filt, Descr, Fmt, SortOrder)
+WHERE NOT EXISTS (SELECT 1 FROM dbo.ReportingMetrics m WHERE m.Code = v.Code);
+GO

--- a/sql/_migrations/NexoraDB/0133_seed_privera_nachsendungen_source.sql
+++ b/sql/_migrations/NexoraDB/0133_seed_privera_nachsendungen_source.sql
@@ -1,0 +1,74 @@
+-- 0133_seed_privera_nachsendungen_source.sql
+-- Privera physische Zustellung (Nachsendungen), from AES Sprint 54 (#329),
+-- after 0130-0132. Replaces
+-- R:\...\Privera\01_Posteingang\Statistik\Privera-Statistik_TP01-physische Zustellung-<YYYYMM>.xlsx
+-- with a source over 01_Privera_Posteingang.dbo.Reporting_P1_Nachsendungen,
+-- the table that workbook's Power Query already reads.
+--
+-- FIRST SOURCE IN ANOTHER DATABASE
+-- Every source before this one lives in SYDOC_Statistik, so BaseObject was
+-- 'dbo.<table>'. This one is three-part. The engine is unchanged -- it is the
+-- same server and the same login, which already has rights here -- but the
+-- identifier guard in nx_lib/reporting/table_query.py had to stop refusing a
+-- name that starts with a digit before '01_Privera_Posteingang' could be
+-- written down at all.
+--
+-- WHAT THE OLD REPORT IS
+-- One pivot: rows = Nachsendungstyp, columns = Niederlassung, a single data
+-- field "Anzahl von DokumenttypNr", page filter ExportDatetime. Underneath it,
+-- a hand-added line labelled "ohne TEC".
+--
+-- THE "ohne TEC" LINE IS A REAL RULE, NOT A FUDGE
+-- August 2026 published 1,667 total and 1,042 "ohne TEC". 1,667 - 1,042 = 625,
+-- which is exactly the "Rechnungen Privera TEC" Nachsendungstyp row. Note it is
+-- *not* the TEC Niederlassung column (610) -- that subtraction gives 1,057 and
+-- would have been the easy wrong guess. Both figures verified against the
+-- workbook, so both are measures here and neither has to be worked out by hand
+-- again.
+--
+-- "Anzahl Seiten" IS NOT EXPOSED
+-- The column exists and would be useful, but its name contains a space and the
+-- catalogue's field keys must match ^[A-Za-z0-9_]+$ (semantic.py). Exposing it
+-- needs the column renamed in the source database or a view over it; it is not
+-- worth loosening a validator that guards interpolated SQL.
+--
+-- Permission follows reporting.source.<code>.use (0088). Idempotent.
+
+INSERT INTO dbo.Permission (Code, Description)
+SELECT N'reporting.source.privera_nachsendungen.use', N'Use the Privera physical forwarding source'
+WHERE NOT EXISTS (SELECT 1 FROM dbo.Permission WHERE Code = N'reporting.source.privera_nachsendungen.use');
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.ReportingSources WHERE Code = 'privera_nachsendungen')
+INSERT INTO dbo.ReportingSources
+    (Code, Kind, Label, Permission, Engine, Provider, BaseObject, ColumnsJSON, Enabled, SortOrder)
+VALUES (
+    'privera_nachsendungen', 'curated', N'Privera — Physische Zustellung',
+    'reporting.source.privera_nachsendungen.use', 'statistics', 'table',
+    '01_Privera_Posteingang.dbo.Reporting_P1_Nachsendungen',
+    N'[{"field":"ExportDatetime","label":"Export date","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"Nachsendungstyp","label":"Forwarding type","type":"string","filterable":true,"sortable":true},
+       {"field":"Niederlassung","label":"Branch","type":"string","filterable":true,"sortable":true},
+       {"field":"Register","label":"Register","type":"string","filterable":true,"sortable":true},
+       {"field":"DossierTyp","label":"Dossier type","type":"string","filterable":true,"sortable":true},
+       {"field":"Dokumenttyp","label":"Document type","type":"string","filterable":true,"sortable":true},
+       {"field":"DokumenttypNr","label":"Document type no.","type":"string","filterable":true,"sortable":true},
+       {"field":"SendungsNr","label":"Consignment no.","type":"string","filterable":true,"sortable":true}]',
+    1, 360);
+GO
+
+INSERT INTO dbo.ReportingMetrics
+    (Code, SourceId, Label, GermanLabel, FrenchLabel, ItalianLabel, Aggregation, BaseField, FilterJson, Description, Format, SortOrder)
+SELECT v.Code, v.SourceId, v.Label, v.De, v.Fr, v.It, v.Agg, v.BaseField, v.Filt, v.Descr, v.Fmt, v.SortOrder
+FROM (VALUES
+    ('privera_nachsendungen_total', 'privera_nachsendungen',
+        N'Forwardings total', N'Nachsendungen gesamt', N'Réexpéditions au total', N'Inoltri in totale',
+        'count', NULL, NULL,
+        N'Every forwarding exported in the period, the workbook''s Gesamtergebnis. Group by Forwarding type and Branch for its breakdown.', 'int', 360),
+    ('privera_nachsendungen_ohne_tec', 'privera_nachsendungen',
+        N'Forwardings without TEC', N'Nachsendungen ohne TEC', N'Réexpéditions sans TEC', N'Inoltri senza TEC',
+        'count', NULL, N'[{"field":"Nachsendungstyp","op":"ne","value":"Rechnungen Privera TEC"}]',
+        N'The workbook''s hand-added "ohne TEC" line: everything except the "Rechnungen Privera TEC" forwarding type. Not the TEC branch -- excluding that gives a different number.', 'int', 361)
+) AS v(Code, SourceId, Label, De, Fr, It, Agg, BaseField, Filt, Descr, Fmt, SortOrder)
+WHERE NOT EXISTS (SELECT 1 FROM dbo.ReportingMetrics m WHERE m.Code = v.Code);
+GO

--- a/tests/unit/test_billing_sources.py
+++ b/tests/unit/test_billing_sources.py
@@ -1,0 +1,206 @@
+r"""Compass Group and Privera billing sources keep their verified shape (#329).
+
+Migrations `0131` and `0132` follow `0130` (Elektro-Material, guarded in
+`test_em_invoice_source.py`). All three replace a hand-refreshed workbook on the
+R: drive with a source over the table that workbook's Power Query already reads.
+
+Each customer's pivot turned out to be a *different* shape, and the differences
+are the whole risk here -- they look like inconsistencies somebody would later
+"tidy up", and tidying any of them changes an invoice:
+
+* Elektro-Material filters every measure on `Eingang`, because its pivot totals
+  two channel rows.
+* **Compass filters nothing.** Its pivot has no channel split and the unfiltered
+  count reproduces the published total exactly. Adding a filter for symmetry
+  with 0130 would change the number.
+* **Compass bills on `UploadDatetime`, not `DocDate`**, even though DocDate is
+  what the pivot shows as its rows. Documents uploaded in one month carry
+  document dates spread over years.
+* **Privera splits on `DocSource`, not on the workbook's `FileName` filter.**
+
+Verified before these were written: Compass exact in 6 of 8 published months
+(off by one in the other two), Privera exact in 5 of 6 published figures. The
+one gap is documented in `test_privera_mail_measure_is_the_honest_definition`.
+"""
+
+import json
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+MIGRATIONS = REPO / "sql" / "_migrations" / "NexoraDB"
+
+COMPASS = MIGRATIONS / "0131_seed_compass_invoice_source.sql"
+PRIVERA = MIGRATIONS / "0132_seed_privera_invoice_source.sql"
+EM = MIGRATIONS / "0130_seed_em_invoice_source.sql"
+
+ALL_BILLING = {"em_invoice": EM, "compass_invoice": COMPASS, "privera_invoice": PRIVERA}
+
+# Columns that exist in these tables and must never reach a catalogue. Billing
+# document volume needs none of them. The Privera ones are the sharpest:
+# LiegenschaftsNr and EigentuemerNr identify a property and its owner.
+NEVER_EXPOSED = (
+    "GrossAmount",
+    "NetAmount",
+    "VatAmount",
+    "BankIBAN",
+    "SPC_IBAN",
+    "IBAN",
+    "ESR",
+    "BankPK",
+    "CrdNO",
+    "CRD_NR",
+    "CRDNAME1",
+    "CRD_NAME_1",
+    "InvoiceNR",
+    "LiegenschaftsNr",
+    "EigentuemerNr",
+)
+
+
+def _sql(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _columns(path):
+    m = re.search(r"N'(\[\{\"field\".*?\])'", _sql(path), re.S)
+    assert m, f"no ColumnsJSON in {path.name}"
+    return {c["field"]: c for c in json.loads(m.group(1))}
+
+
+def _measure_block(path, code):
+    """The VALUES row for one measure, as raw text."""
+    m = re.search(
+        rf"\('{re.escape(code)}',\s*'[a-z_]+',(.*?)\n\s*\)?\)?,?\s*(?=\('|\) AS v)",
+        _sql(path),
+        re.S,
+    )
+    assert m, f"measure {code} not found in {path.name}"
+    return m.group(1)
+
+
+def _filter_of(path, code):
+    """Parsed FilterJson for a measure, or None when it has none."""
+    block = _measure_block(path, code)
+    m = re.search(r"N'(\[\{.*?\}\])'", block, re.S)
+    return json.loads(m.group(1)) if m else None
+
+
+# --------------------------------------------------------------------------
+# Shared across every billing source.
+# --------------------------------------------------------------------------
+
+
+def test_all_three_billing_migrations_exist():
+    for code, path in ALL_BILLING.items():
+        assert path.exists(), f"{path.name} is gone -- retarget these guards"
+        assert f"'{code}'" in _sql(path)
+
+
+def test_every_billing_source_creates_its_own_permission():
+    """A table source gets no row scoping, so the permission is the whole gate
+    between one internal customer's figures and another's."""
+    for code, path in ALL_BILLING.items():
+        sql = _sql(path)
+        assert f"reporting.source.{code}.use" in sql
+        assert "dbo.Permission" in sql, f"{path.name} never creates the permission row"
+
+
+def test_no_billing_source_exposes_amounts_bank_details_or_property_ids():
+    for code, path in ALL_BILLING.items():
+        leaked = set(_columns(path)) & set(NEVER_EXPOSED)
+        assert not leaked, f"{code} exposes {sorted(leaked)} -- not needed to bill volume"
+
+
+# --------------------------------------------------------------------------
+# Compass Group.
+# --------------------------------------------------------------------------
+
+
+def test_compass_bills_on_the_upload_date():
+    """DocDate is what the pivot *shows*; UploadDatetime is what it *filters*.
+    Counting by DocDate bills a different set of documents entirely -- the May
+    2026 workbook has rows dated 2022, 2024 and 2025, and 235 with no usable
+    date at all."""
+    cols = _columns(COMPASS)
+    assert "UploadDatetime" in cols, "the billing period column is not exposed"
+    assert cols["UploadDatetime"]["type"] == "date"
+    assert cols["UploadDatetime"].get("grainable") is True, "cannot group by month"
+
+
+def test_compass_measure_has_no_channel_filter():
+    """Deliberately unlike 0130. Compass's pivot has no channel split and its
+    unfiltered count reproduces the published total exactly, so 'harmonising'
+    it with Elektro-Material would change an invoice."""
+    assert (
+        _filter_of(COMPASS, "compass_documents") is None
+    ), "compass_documents gained a filter -- its published total is unfiltered"
+
+
+def test_compass_keeps_channel_as_a_dimension_not_a_filter():
+    assert "Eingang" in _columns(COMPASS), "Eingang should stay available to group by"
+
+
+# --------------------------------------------------------------------------
+# Privera Rechnungseingang.
+# --------------------------------------------------------------------------
+
+
+def test_privera_registers_the_three_published_figures():
+    """gesamt / Mail / eBill -- the workbook publishes three pivots, so three
+    measures."""
+    sql = _sql(PRIVERA)
+    for code in ("privera_documents", "privera_mail_documents", "privera_ebill_documents"):
+        assert f"'{code}'" in sql, f"{code} is missing"
+
+
+def test_privera_total_counts_every_source():
+    assert (
+        _filter_of(PRIVERA, "privera_documents") is None
+    ), "the total must not be filtered -- it counts every document exported"
+
+
+def test_privera_splits_on_docsource_not_filename():
+    """The workbook splits Mail from eBill with a list of ticked file names,
+    which is neither reproducible nor meaningful. DocSource carries the same
+    classification as data and partitions the month exactly."""
+    for code, expected in (
+        ("privera_mail_documents", "MAIL"),
+        ("privera_ebill_documents", "eBill"),
+    ):
+        cond = _filter_of(PRIVERA, code)
+        assert cond, f"{code} has no filter"
+        assert {c["field"] for c in cond} == {
+            "DocSource"
+        }, f"{code} should key on DocSource, not on file names"
+        assert [c["value"] for c in cond] == [expected]
+
+
+def test_privera_mail_measure_is_the_honest_definition():
+    """The known, deliberate difference. The old Mail pivot dropped mail
+    documents with no Mandant while its total counted them, so its August 2026
+    figure was 5 lower. That is an inconsistency in the report, not a billing
+    rule, so it is not welded into the metric -- Mandant stays a dimension so
+    anyone who wants the old behaviour can filter for it."""
+    cond = _filter_of(PRIVERA, "privera_mail_documents")
+    assert {c["field"] for c in cond} == {"DocSource"}, (
+        "a Mandant condition crept into the mail measure -- that was an artefact "
+        "of the old workbook, not a rule anyone agreed"
+    )
+    assert "Mandant" in _columns(
+        PRIVERA
+    ), "Mandant must stay a dimension, or the old behaviour is unreachable"
+
+
+def test_privera_bills_on_the_export_date():
+    cols = _columns(PRIVERA)
+    assert "ExportDate" in cols
+    assert cols["ExportDate"].get("grainable") is True
+
+
+def test_privera_measures_carry_all_four_languages():
+    for code in ("privera_documents", "privera_mail_documents", "privera_ebill_documents"):
+        block = _measure_block(PRIVERA, code)
+        labels = re.findall(r"N'((?:[^']|'')*)'", block.split("'count'")[0])
+        assert len(labels) == 4, f"{code} has {len(labels)} labels, expected 4"
+        assert all(x.strip() for x in labels), f"{code} has a blank label"

--- a/tests/unit/test_billing_sources.py
+++ b/tests/unit/test_billing_sources.py
@@ -32,9 +32,15 @@ MIGRATIONS = REPO / "sql" / "_migrations" / "NexoraDB"
 
 COMPASS = MIGRATIONS / "0131_seed_compass_invoice_source.sql"
 PRIVERA = MIGRATIONS / "0132_seed_privera_invoice_source.sql"
+NACHSEND = MIGRATIONS / "0133_seed_privera_nachsendungen_source.sql"
 EM = MIGRATIONS / "0130_seed_em_invoice_source.sql"
 
-ALL_BILLING = {"em_invoice": EM, "compass_invoice": COMPASS, "privera_invoice": PRIVERA}
+ALL_BILLING = {
+    "em_invoice": EM,
+    "compass_invoice": COMPASS,
+    "privera_invoice": PRIVERA,
+    "privera_nachsendungen": NACHSEND,
+}
 
 # Columns that exist in these tables and must never reach a catalogue. Billing
 # document volume needs none of them. The Privera ones are the sharpest:
@@ -91,7 +97,7 @@ def _filter_of(path, code):
 # --------------------------------------------------------------------------
 
 
-def test_all_three_billing_migrations_exist():
+def test_all_billing_migrations_exist():
     for code, path in ALL_BILLING.items():
         assert path.exists(), f"{path.name} is gone -- retarget these guards"
         assert f"'{code}'" in _sql(path)
@@ -204,3 +210,44 @@ def test_privera_measures_carry_all_four_languages():
         labels = re.findall(r"N'((?:[^']|'')*)'", block.split("'count'")[0])
         assert len(labels) == 4, f"{code} has {len(labels)} labels, expected 4"
         assert all(x.strip() for x in labels), f"{code} has a blank label"
+
+
+# --------------------------------------------------------------------------
+# Privera physische Zustellung -- the first source in another database.
+# --------------------------------------------------------------------------
+
+
+def test_nachsendungen_points_at_the_other_database():
+    """Every earlier source is 'dbo.<table>' in SYDOC_Statistik. This one is
+    three-part, and it is the reason the identifier guard had to stop refusing
+    names that start with a digit."""
+    from nx_lib.reporting.table_query import _quote_object
+
+    m = re.search(r"'(01_Privera_Posteingang\.dbo\.[A-Za-z0-9_]+)'", _sql(NACHSEND))
+    assert m, "the three-part BaseObject is gone from the migration"
+    # Not just present in the text: the query layer has to accept it.
+    assert _quote_object(m.group(1)).startswith("[01_Privera_Posteingang].")
+
+
+def test_nachsendungen_registers_both_published_figures():
+    sql = _sql(NACHSEND)
+    for code in ("privera_nachsendungen_total", "privera_nachsendungen_ohne_tec"):
+        assert f"'{code}'" in sql, f"{code} is missing"
+    assert (
+        _filter_of(NACHSEND, "privera_nachsendungen_total") is None
+    ), "the total must count every forwarding"
+
+
+def test_ohne_tec_excludes_the_forwarding_type_not_the_branch():
+    """The trap. August 2026 published 1,667 total and 1,042 'ohne TEC'. The
+    difference, 625, is the 'Rechnungen Privera TEC' *Nachsendungstyp* row --
+    excluding the TEC *Niederlassung* instead gives 1,057, which looks just as
+    plausible and is wrong. Both verified against July and August."""
+    cond = _filter_of(NACHSEND, "privera_nachsendungen_ohne_tec")
+    assert cond, "the ohne-TEC measure lost its filter"
+    assert {c["field"] for c in cond} == {"Nachsendungstyp"}, (
+        "ohne TEC must exclude a forwarding type, not a branch -- excluding the "
+        "TEC Niederlassung gives a different number"
+    )
+    assert cond[0]["op"] == "ne"
+    assert cond[0]["value"] == "Rechnungen Privera TEC"

--- a/tests/unit/test_em_invoice_source.py
+++ b/tests/unit/test_em_invoice_source.py
@@ -1,0 +1,168 @@
+r"""The Elektro-Material billing source keeps the shape it was verified in (#329).
+
+Migration `0130` registers `dbo.EM_Invoice` as a reporting source so the monthly
+Verrechnung stops being a hand-refreshed workbook. The measures were not
+invented: they were read out of that workbook's own pivot definition (rows =
+`Eingang`, data fields = `Anzahl von DocBarcode` / `Summe von AnzImagesOut` /
+`Summe von OrdItmPosCount`) and then checked against six published months.
+
+Two decisions in that migration are load-bearing and silent if broken, which is
+why they are pinned here rather than left to review:
+
+* **Every measure filters on `Eingang`.** The workbook's total is the sum of its
+  two rows, OPEX + E_MAIL. Across the whole table `Eingang` also takes `Nexora`
+  and NULL, so an unfiltered `SUM` would bill rows the workbook never counted --
+  and it would do it quietly, in a month nobody re-checks.
+* **The amount and bank columns stay out of the catalogue.** `EM_Invoice` carries
+  GrossAmount/NetAmount/VatAmount, IBANs, creditor numbers and names. Billing
+  scan volume needs none of it, and a column absent from `ColumnsJSON` cannot be
+  selected, filtered or sorted by anyone holding the source permission.
+
+These read the migration text. The figures themselves cannot be asserted without
+the statistics database, and that verification lives in the issue.
+"""
+
+import json
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+MIGRATION = REPO / "sql" / "_migrations" / "NexoraDB" / "0130_seed_em_invoice_source.sql"
+
+# The two intake channels the workbook's pivot shows as its rows. Anything the
+# source bills has to be one of these.
+BILLED_CHANNELS = {"OPEX Scan Scanner", "E_MAIL"}
+
+# Present in EM_Invoice, deliberately not exposed. Not an exhaustive list of
+# sensitive columns -- an exhaustive list would rot; these are the ones whose
+# appearance would mean somebody widened the catalogue without thinking.
+MUST_NOT_BE_EXPOSED = (
+    "GrossAmount",
+    "NetAmount",
+    "VatAmount",
+    "BankIBAN",
+    "SPC_IBAN",
+    "BankPK",
+    "CrdNO",
+    "CRDNAME1",
+    "InvoiceNR",
+)
+
+EXPECTED_MEASURES = {
+    "em_documents": "count",
+    "em_opex_scans": "count",
+    "em_email_documents": "count",
+    "em_order_positions": "sum",
+    "em_images_out": "sum",
+}
+
+
+def _sql():
+    return MIGRATION.read_text(encoding="utf-8")
+
+
+def _columns_json():
+    """The source's ColumnsJSON, parsed."""
+    m = re.search(r"N'(\[\{\"field\".*?\])'", _sql(), re.S)
+    assert m, "could not find ColumnsJSON in the migration"
+    return json.loads(m.group(1))
+
+
+def _filter_jsons():
+    """Every FilterJson literal in the measure insert, parsed, by measure code."""
+    out = {}
+    for code in EXPECTED_MEASURES:
+        m = re.search(
+            rf"\('{re.escape(code)}',\s*'em_invoice',.*?N'(\[\{{.*?\}}\])'",
+            _sql(),
+            re.S,
+        )
+        assert m, f"no FilterJson found for {code}"
+        out[code] = json.loads(m.group(1))
+    return out
+
+
+def test_the_migration_exists_and_registers_the_source():
+    """If this file is renamed the rest of the guards pass vacuously."""
+    assert MIGRATION.exists(), f"{MIGRATION.name} is gone -- retarget this guard"
+    sql = _sql()
+    assert "dbo.ReportingSources" in sql
+    assert "'em_invoice'" in sql
+    assert "'dbo.EM_Invoice'" in sql
+
+
+def test_the_source_is_gated_by_its_own_permission():
+    """A table source gets no row scoping -- the permission is the whole gate."""
+    sql = _sql()
+    assert "reporting.source.em_invoice.use" in sql
+    assert "dbo.Permission" in sql, "the permission row is not created"
+
+
+def test_every_measure_is_registered_with_the_expected_aggregation():
+    sql = _sql()
+    for code, agg in EXPECTED_MEASURES.items():
+        assert f"'{code}'" in sql, f"measure {code} is missing"
+        m = re.search(rf"\('{re.escape(code)}',\s*'em_invoice',.*?'({agg})'", sql, re.S)
+        assert m, f"measure {code} does not aggregate with {agg}"
+
+
+def test_every_measure_is_restricted_to_the_billed_channels():
+    """The one that would silently over-bill. An unfiltered sum would pick up
+    the `Nexora` and NULL `Eingang` rows the workbook never counted."""
+    for code, cond in _filter_jsons().items():
+        fields = {c["field"] for c in cond}
+        assert fields == {"Eingang"}, f"{code} filters on {fields}, expected Eingang"
+        values = set()
+        for c in cond:
+            v = c["value"]
+            values.update(v if isinstance(v, list) else [v])
+        assert (
+            values <= BILLED_CHANNELS
+        ), f"{code} bills {values - BILLED_CHANNELS}, which the workbook never counted"
+
+
+def test_the_split_measures_cover_the_total_between_them():
+    """Opex + e-mail must be exactly what the combined measures bill, or the
+    two halves stop reconciling with the total the customer is invoiced."""
+    f = _filter_jsons()
+    halves = set()
+    for code in ("em_opex_scans", "em_email_documents"):
+        for c in f[code]:
+            halves.add(c["value"])
+    assert halves == BILLED_CHANNELS
+    for code in ("em_documents", "em_order_positions", "em_images_out"):
+        values = set()
+        for c in f[code]:
+            values.update(c["value"])
+        assert values == BILLED_CHANNELS, f"{code} does not cover both channels"
+
+
+def test_the_date_column_is_the_real_datetime_not_the_text_one():
+    """ExportEM is nvarchar holding 'dd.mm.yyyy HH:MM:SS' -- unsortable and
+    ungrainable, and the reason the old report needs a human to tick timestamps
+    out of a filter list every month."""
+    fields = {c["field"]: c for c in _columns_json()}
+    assert "ExportEM_dt" in fields, "the source does not expose ExportEM_dt"
+    assert fields["ExportEM_dt"]["type"] == "date"
+    assert fields["ExportEM_dt"].get("grainable") is True, "cannot group by month"
+    assert "ExportEM" not in fields, "the text export column must stay out"
+
+
+def test_amount_and_bank_columns_are_not_exposed():
+    """Billing scan volume needs none of it, and what is not in the catalogue
+    cannot be queried by a permission holder."""
+    exposed = {c["field"] for c in _columns_json()}
+    leaked = exposed & set(MUST_NOT_BE_EXPOSED)
+    assert not leaked, f"catalogue exposes {sorted(leaked)} -- not needed to bill volume"
+
+
+def test_measures_carry_all_four_languages():
+    """A missing translation shows the English label to a German user, which is
+    how a billing figure gets misread."""
+    sql = _sql()
+    for code in EXPECTED_MEASURES:
+        m = re.search(rf"\('{re.escape(code)}',\s*'em_invoice',\s*(.*?)'(count|sum)'", sql, re.S)
+        assert m, f"cannot read the label block for {code}"
+        labels = re.findall(r"N'((?:[^']|'')*)'", m.group(1))
+        assert len(labels) == 4, f"{code} has {len(labels)} labels, expected 4"
+        assert all(label.strip() for label in labels), f"{code} has a blank label"

--- a/tests/unit/test_reporting_table_query.py
+++ b/tests/unit/test_reporting_table_query.py
@@ -351,3 +351,56 @@ def test_generic_aggregate_conditional_metric_params_precede_where_params():
     assert "COUNT(CASE WHEN [Status] = ? THEN 1 END) AS [ok_rows]" in sql
     assert "WHERE [Region] <> ?" in sql
     assert params == ["ok", "north"]
+
+
+# ---------------------------------------------------------------------------
+# Object naming. Relaxed in #329 so a source can point at a database whose name
+# starts with a digit (`01_Privera_Posteingang`). The relaxation moves *where* a
+# digit may appear and nothing else, so these pin both halves: the new name is
+# accepted, and every character that could break out of the bracket quoting is
+# still refused.
+# ---------------------------------------------------------------------------
+
+
+def test_database_name_starting_with_a_digit_is_accepted():
+    """Real databases on the statistics server are named `01_<Customer>_<Thing>`.
+    Refusing them meant a whole customer's billing source could not be
+    registered at all."""
+    from nx_lib.reporting.table_query import _quote_object
+
+    assert _quote_object("01_Privera_Posteingang.dbo.Reporting_P1_Nachsendungen") == (
+        "[01_Privera_Posteingang].[dbo].[Reporting_P1_Nachsendungen]"
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "db.dbo.tbl]; DROP TABLE x --",  # closes the bracket quote early
+        "a b",  # whitespace
+        "a'b",  # string delimiter
+        'a"b',
+        "a;b",  # statement separator
+        "a-b",  # comment lead-in when doubled
+        "a[b",
+        "a/*b",
+        "täbelle",  # non-ASCII: outside the allowed set on purpose
+    ],
+)
+def test_identifiers_that_could_escape_the_quoting_are_still_refused(name):
+    """The guard is the only thing between a registry row and interpolated SQL:
+    BaseObject is written by an admin, not a query parameter, so it is never
+    bound. Loosening the character set would be a different change entirely
+    from loosening the leading-digit rule."""
+    from nx_lib.reporting.table_query import _quote_object
+
+    with pytest.raises(TableQueryError):
+        _quote_object(f"db.dbo.{name}")
+
+
+@pytest.mark.parametrize("name", ["", "a..b", "a.b.c.d", None])
+def test_object_names_must_have_one_to_three_non_empty_parts(name):
+    from nx_lib.reporting.table_query import _quote_object
+
+    with pytest.raises(TableQueryError):
+        _quote_object(name)


### PR DESCRIPTION
First of the six from #329. Elektro-Material goes first because it is the one
the ticket specifies in full, so it sets the pattern for the rest.

Migration `0130` registers `SYDOC_Statistik.dbo.EM_Invoice` as a reporting
source. That is the same table `EM-Statistik<YYYYMM>.xlsx` already reads through
Power Query, so nothing is imported or copied — the numbers come from where they
already live.

### The measures are the workbook's own pivot

Not guessed from the sheet. That workbook is a single pivot and its definition
names the fields: rows = `Eingang`, page filter = `ExportEM`, data fields =
`Anzahl von DocBarcode`, `Summe von AnzImagesOut`, `Summe von OrdItmPosCount`.

| measure | what it is |
|---|---|
| `em_documents` | count, `Eingang IN ('OPEX Scan Scanner','E_MAIL')` |
| `em_opex_scans` | count, `Eingang = 'OPEX Scan Scanner'` |
| `em_email_documents` | count, `Eingang = 'E_MAIL'` |
| `em_order_positions` | sum of `OrdItmPosCount`, same filter |
| `em_images_out` | sum of `AnzImagesOut`, same filter |

### Verified against six published months

I read the published figures straight out of each workbook's `sheet1.xml` (a
handful of cells — never the ~140 MB pivot cache), then built the SQL **from the
registry using nexora's own resolver** and ran it against the statistics
database. So what was tested is what the reporting page will run, not a
hand-written query that happens to agree.

`em_opex_scans` and `em_order_positions` reproduce **exactly** in four of the six
months. Worst single deviation 1.06%.

### One finding that matters more than this PR

Every difference is negative. Re-running a past month today returns *fewer* rows
than the workbook captured at the time — May is 2 documents short, August 103.
It is not rows without a barcode and not a delete flag: `COUNT(*)` equals
`COUNT(DocBarcode)`, `DeleteByUser` is 0, and `GeloeschtAm` is set on every row
so it is not a deletion marker. Either rows leave the table or `ExportEM_dt`
moves when a document is re-exported.

So **the monthly figure is not stable**, which for billing means whatever gets
invoiced has to be frozen at billing time rather than recomputed later. That is a
property of the source, not of these measures, and it is written up on #329.

### Two choices pinned by tests, because both fail quietly

- **Every measure filters `Eingang` to the two billed channels.** The workbook's
  total is the sum of its two rows, but the table also holds `Nexora` and NULL
  rows. An unfiltered sum would bill documents the customer was never charged
  for, in a month nobody re-checks. Putting `Nexora` back into one filter fails
  two tests by name.
- **The amount, IBAN and creditor columns stay out of `ColumnsJSON`.**
  `EM_Invoice` carries GrossAmount/NetAmount/VatAmount, IBANs, creditor numbers
  and names. Billing scan volume needs none of it, and a column absent from the
  catalogue cannot be selected, filtered or sorted by a permission holder. Note
  a `table` source gets no row scoping — the permission is the whole gate.

`ExportEM_dt` is the grainable date rather than the `ExportEM` nvarchar beside
it. That text column, holding `dd.mm.yyyy HH:MM:SS`, is exactly why the current
report needs someone to tick the right timestamps out of a filter list every
month.

### Before merging

Someone who does the invoicing should confirm the five measures are the billed
figures. The ticket names three of them outright; `em_images_out` and the
Opex/e-mail split come from the pivot, which is good evidence but not the same as
being told.

8 new tests, full unit tier green (1812). Migration applied to INT.
