### PR TITLE
fix(permissions): drop the dormant MediaMarkt grant from Sydoc User (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,17 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   old copy still writes — see `scripts/generali-import/README.md`.
 
 ### Fixed
+- **Dropped a dormant reporting grant** (#332) — migration `0134` removes
+  `reporting.source.mediamarkt_batches.use` from the `Sydoc User` profile. That
+  profile has 8 users and does not hold `reporting.view`, so every reporting
+  route already refused it and the grant did nothing — but it would have gone
+  live the moment anyone added `reporting.view` to the profile while thinking
+  about something else. The `table` provider applies no row scoping, so a source
+  permission is the entire gate and there is no second check to catch a grant
+  nobody meant. The pairing was made by hand rather than by a migration, which
+  is why INT never had it; the migration is a no-op there and a correction on
+  PROD. The same permission stays with Global Admin and Sydoc Supervisor, who
+  hold `reporting.view` and are meant to have it.
 - **env-sync's ACTION NEEDED no longer cries wolf** (#313) — the headline
   alarm fired on 11 keys absent from `env/PROD.env` on the server, and all 11
   were false positives: each has a code default identical to the value

--- a/sql/_migrations/NexoraDB/0134_drop_dormant_mediamarkt_grant.sql
+++ b/sql/_migrations/NexoraDB/0134_drop_dormant_mediamarkt_grant.sql
@@ -1,0 +1,38 @@
+-- 0134_drop_dormant_mediamarkt_grant.sql
+-- Remove reporting.source.mediamarkt_batches.use from the 'Sydoc User' profile
+-- (#332).
+--
+-- WHY
+-- That profile has 8 users and does NOT hold reporting.view, so every reporting
+-- route already refuses it and the grant does nothing today. It is a trap rather
+-- than a leak: the day somebody adds reporting.view to 'Sydoc User' -- thinking
+-- about reporting access, not about MediaMarkt -- those 8 users silently gain a
+-- customer's batch figures in the same click.
+--
+-- The `table` provider applies no row scoping, so a source permission is the
+-- whole gate. There is no second check to catch a grant nobody meant to make,
+-- which is exactly why a half-finished one should not be left lying around.
+--
+-- WHERE IT CAME FROM
+-- Not from a migration. 0126 created the permission and registered the source
+-- but granted it to nobody; this pairing was made by hand in the admin UI. INT
+-- does not have it -- there, only Enterprise Admin holds the source -- so this
+-- migration is a no-op on INT and a correction on PROD. That divergence is the
+-- reason it is being fixed in a migration rather than by another click: this
+-- way both environments end up saying the same thing.
+--
+-- NOT TOUCHED
+-- The same permission is also held on PROD by Global Admin and Sydoc Supervisor.
+-- Both hold reporting.view, both are internal SYDOC staff, and both grants are
+-- intentional. Only the dormant one goes.
+--
+-- Idempotent: a DELETE that matches nothing is a no-op, and re-granting the
+-- permission deliberately later is unaffected (migrations run once).
+
+DELETE app
+FROM dbo.AccessProfilePermission app
+JOIN dbo.AccessProfile ap ON ap.AccessID = app.AccessID
+JOIN dbo.Permission p ON p.PermissionID = app.PermissionID
+WHERE ap.Name = N'Sydoc User'
+  AND p.Code = N'reporting.source.mediamarkt_batches.use';
+GO


### PR DESCRIPTION
First item of #332.

The `Sydoc User` profile — **8 users** — holds `reporting.source.mediamarkt_batches.use` but not `reporting.view`. Every reporting route already refuses it, so it grants nothing today.

It is a trap rather than dead weight. Adding `reporting.view` to that profile for any unrelated reason would hand those 8 users a customer's batch figures in the same click, and the `table` provider applies no row scoping, so the source permission is the entire gate — nothing else would catch it.

### Why a migration and not a click in the admin UI

The pairing was never made by a migration. `0126` created the permission and registered the source but granted it to nobody, so somebody did this by hand. That is why the two environments disagree:

| | holders of `reporting.source.mediamarkt_batches.use` |
|---|---|
| INT | Enterprise Admin |
| PROD | Enterprise Admin, Global Admin, Sydoc Supervisor, **Sydoc User** |

Doing it as a migration leaves a record and makes both environments agree. Applied to INT already — **0 rows affected**, exactly the expected no-op. On PROD it removes one row.

### Left alone deliberately

Global Admin and Sydoc Supervisor hold the same permission on PROD. Both hold `reporting.view`, both are internal SYDOC staff, both grants are intentional. Only the dormant one goes.

### No test, on purpose

This is a one-time correction with no ongoing semantics — a test would only restate the `DELETE`. The lasting guard is the second item on #332: teach `scripts/perm-audit.py` to flag any source grant held without `reporting.view`, and any profile holding a source belonging to a different customer. Neither is detectable by reading the permissions grid, and neither exists today.