### PR TITLE
feat(reporting): the last two billing sources — Neuzugaenge and Posteingang (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Privera Posteingang reporting source — the last of the six** (#329) —
+  migration `0135` registers
+  `01_Privera_Posteingang.dbo.Reporting_P1_Dokumente`. Its `ExportDatetime` is
+  text (`dd.MM.yyyy HH:mm:ss`) and the connection runs `us_english`, which
+  reads `01.02.2021` as 2 January and errors outright past the 12th, so the
+  column is exposed as a **string** and a month is a `contains` filter
+  (`.08.2026`). That reproduces the published 10,044 for August exactly, cell
+  for cell across the Register × Niederlassung grid, and matches how the
+  workbook itself works — one file per month. The cost is no month grain, so no
+  series over time; recovering it is one added column on that view
+  (`TRY_CONVERT(datetime, ExportDatetime, 104)`), after which it becomes a
+  grainable date with no other change.
 - **Privera Neuzugänge reporting source** (#329) — migration `0134` registers
   `dbo.v_PriveraNeuzugaenge_StatistikNiederlassung_AnzahlDossiers`, the view
   behind the Initialscanning workbook. The view is already aggregated per

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Privera Neuzugänge reporting source** (#329) — migration `0134` registers
+  `dbo.v_PriveraNeuzugaenge_StatistikNiederlassung_AnzahlDossiers`, the view
+  behind the Initialscanning workbook. The view is already aggregated per
+  month and branch, so all three measures — Dossiers, Registers, Pages — are
+  plain sums, and year and month stay numeric dimensions because there is no
+  date column to group by. Verified against the published 2026 workbook: all
+  six closed months exact on all three measures, the only differences being
+  September, which was one day old when that workbook was refreshed. The
+  workbook's fourth data field, a summed `JahrExport`, is an accident and is
+  deliberately not reproduced. Note the view is **broken on INT** (it binds to
+  a stray `SYDOC_Statistik1`) and works on PROD, so the source errors on INT
+  until the dev copy is repointed.
 - **Privera physische Zustellung reporting source, and cross-database sources**
   (#329) — migration `0133` registers
   `01_Privera_Posteingang.dbo.Reporting_P1_Nachsendungen`, the first source

--- a/docs/howto/reporting.md
+++ b/docs/howto/reporting.md
@@ -1312,7 +1312,26 @@ changes: its `ExportDatetime` is `nvarchar` holding `dd.MM.yyyy HH:mm:ss`, and
 our connection runs `us_english`, so grouping it by month parses `01.02.2021` as
 **2 January** and raises outright on any day past the 12th. It needs a real
 datetime column (the `ExportEM`/`ExportEM_dt` pattern) or a view using
-`TRY_CONVERT(..., 104)`. The wizard's measure step walks
+`TRY_CONVERT(..., 104)`. `0134` adds **Privera — Neuzugänge**
+(`privera_neuzugaenge` over
+`dbo.v_PriveraNeuzugaenge_StatistikNiederlassung_AnzahlDossiers`). The view is
+already aggregated — one row per year/month/Niederlassung carrying three
+counters — so all three measures (`Dossiers`, `Registers`, `Pages`) are plain
+sums and there is **no date grain**: the view has no date column, only a year
+and a month number, which are ordinary numeric dimensions. The workbook's pivot
+carries a fourth data field, "Summe von JahrExport", which is the year dropped
+into the values by accident; it is deliberately not reproduced, and a test
+checks it never is. Verified against the published 2026 workbook: all six closed
+months exact on all three measures (18 of 21 figures), the three misses being
+September, which was one day old when that workbook was refreshed. `SortOrder`
+370.
+
+**This view is broken on INT** — it binds to
+`SYDOC_Statistik1.dbo.PriveraInitialUndNeuzugaenge`, note the stray `1`, so
+selecting from it fails with a 4413 binding error. It works on PROD. The source
+is registered anyway, because the registry rows are data and the workbook it
+replaces runs against PROD; expect the source to error on INT until somebody
+repoints the dev copy of the view. The wizard's measure step walks
 sources in `SortOrder` and splits a `Tenant — Thing` label at the em dash: one
 uppercase heading per tenant, a `.rs-choice-group-sublabel` per source. The
 tenant's lookup tables carry no measures and are not registered. Each source is gated by its own

--- a/docs/howto/reporting.md
+++ b/docs/howto/reporting.md
@@ -1331,7 +1331,24 @@ September, which was one day old when that workbook was refreshed. `SortOrder`
 selecting from it fails with a 4413 binding error. It works on PROD. The source
 is registered anyway, because the registry rows are data and the workbook it
 replaces runs against PROD; expect the source to error on INT until somebody
-repoints the dev copy of the view. The wizard's measure step walks
+repoints the dev copy of the view.
+
+`0135` adds **Privera — Posteingang** (`privera_posteingang` over
+`01_Privera_Posteingang.dbo.Reporting_P1_Dokumente`), completing the six.
+Its `ExportDatetime` is **nvarchar** holding `dd.MM.yyyy HH:mm:ss`, so it is
+exposed as a **string**, not a date: the connection runs `us_english`, which
+reads `01.02.2021` as 2 January and raises outright on any day past the 12th
+(both measured against PROD). A month is therefore a `contains` filter —
+`.08.2026` renders as `LIKE '%.08.2026%'` and reproduces the published 10,044
+exactly, cell for cell across the Register × Niederlassung grid. That matches
+how the workbook works, one file per month with the month ticked in a filter, so
+nothing is lost against what it replaces. What *is* lost is a month grain, so no
+series over time. The fix belongs in the source database and is one added column
+on that view — `TRY_CONVERT(datetime, ExportDatetime, 104) AS ExportDatetime_dt`
+— after which adding it to `ColumnsJSON` as a grainable date is the whole
+change. Teaching the reporting layer to parse text dates was considered and
+rejected: it would wrap every reference to the column in shared code, for one
+column in one view, and defeat any index over 858k rows. `SortOrder` 380. The wizard's measure step walks
 sources in `SortOrder` and splits a `Tenant — Thing` label at the em dash: one
 uppercase heading per tenant, a `.rs-choice-group-sublabel` per source. The
 tenant's lookup tables carry no measures and are not registered. Each source is gated by its own

--- a/sql/_migrations/NexoraDB/0134_seed_privera_neuzugaenge_source.sql
+++ b/sql/_migrations/NexoraDB/0134_seed_privera_neuzugaenge_source.sql
@@ -1,0 +1,79 @@
+-- 0134_seed_privera_neuzugaenge_source.sql
+-- Privera Neuzugänge (Initialscanning), from AES Sprint 54 (#329), after
+-- 0130-0133. Replaces
+-- R:\...\Privera\02_Initialscanning\Statistik\PRIVERA Exportierte Neuzugaenge pro Niederlassung_2024.xlsx
+-- with a source over the view that workbook's Power Query already reads.
+--
+-- READ THIS BEFORE TESTING ON INT
+-- The view works on PROD -- 240 rows, current data. On INT it is BROKEN: it
+-- binds to SYDOC_Statistik1.dbo.PriveraInitialUndNeuzugaenge, note the stray
+-- "1", evidently a restore artefact, and selecting from it fails with
+--   Invalid object name 'SYDOC_Statistik1.dbo.PriveraInitialUndNeuzugaenge' (208)
+--   Could not use view or function ... because of binding errors (4413)
+-- So this source will error on INT and work on PROD until somebody repoints the
+-- INT copy of the view. Registering it is still right: the registry rows are
+-- just data, the workbook it replaces runs against PROD, and holding the whole
+-- source back over a broken *dev* copy would be the wrong trade.
+--
+-- WHY EVERY MEASURE IS A SUM AND THERE IS NO DATE GRAIN
+-- The view is already aggregated: one row per JahrExport / MonatExportNr /
+-- Niederlassung carrying three counters. There is no date column to group by --
+-- only a year and a month number -- so those two are ordinary numeric
+-- dimensions here rather than a grainable date. That is not a limitation worth
+-- working around: the data has no finer resolution than a month anyway.
+--
+-- WHAT THE OLD REPORT IS
+-- One pivot: rows Niederlassung, columns MonatExport, page filter JahrExport,
+-- three data fields -- Dossiers, Register, Seiten. It carries a fourth,
+-- "Summe von JahrExport", which is plainly somebody dropping the year into the
+-- values by accident (it totals 32,416 for 2026). Not reproduced.
+--
+-- Verified against the published 2026 workbook: January 191/751/8052, February
+-- 137/528/9496, April 137/538/3676, June 365/1437/10687, July 34/132/485,
+-- August 2/8/108 -- every closed month exact. September differs only because
+-- the workbook was refreshed on 2026-09-01, when the month was one day old.
+--
+-- Permission follows reporting.source.<code>.use (0088). Idempotent.
+
+INSERT INTO dbo.Permission (Code, Description)
+SELECT N'reporting.source.privera_neuzugaenge.use', N'Use the Privera Neuzugänge source'
+WHERE NOT EXISTS (SELECT 1 FROM dbo.Permission WHERE Code = N'reporting.source.privera_neuzugaenge.use');
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.ReportingSources WHERE Code = 'privera_neuzugaenge')
+INSERT INTO dbo.ReportingSources
+    (Code, Kind, Label, Permission, Engine, Provider, BaseObject, ColumnsJSON, Enabled, SortOrder)
+VALUES (
+    'privera_neuzugaenge', 'curated', N'Privera — Neuzugänge',
+    'reporting.source.privera_neuzugaenge.use', 'statistics', 'table',
+    'dbo.v_PriveraNeuzugaenge_StatistikNiederlassung_AnzahlDossiers',
+    N'[{"field":"JahrExport","label":"Export year","type":"number","filterable":true,"sortable":true},
+       {"field":"MonatExportNr","label":"Export month no.","type":"number","filterable":true,"sortable":true},
+       {"field":"MonatExport","label":"Export month","type":"string","filterable":true,"sortable":true},
+       {"field":"Niederlassung","label":"Branch","type":"string","filterable":true,"sortable":true},
+       {"field":"AnzahlDossiersExport","label":"Dossiers","type":"number","filterable":true,"sortable":true},
+       {"field":"AnzahlRegisterExport","label":"Registers","type":"number","filterable":true,"sortable":true},
+       {"field":"AnzahlSeitenExport","label":"Pages","type":"number","filterable":true,"sortable":true},
+       {"field":"Abfragedatum","label":"Queried at","type":"date","filterable":true,"sortable":true,"grainable":true}]',
+    1, 370);
+GO
+
+INSERT INTO dbo.ReportingMetrics
+    (Code, SourceId, Label, GermanLabel, FrenchLabel, ItalianLabel, Aggregation, BaseField, FilterJson, Description, Format, SortOrder)
+SELECT v.Code, v.SourceId, v.Label, v.De, v.Fr, v.It, v.Agg, v.BaseField, v.Filt, v.Descr, v.Fmt, v.SortOrder
+FROM (VALUES
+    ('privera_neuzugaenge_dossiers', 'privera_neuzugaenge',
+        N'Dossiers', N'Dossiers', N'Dossiers', N'Dossier',
+        'sum', 'AnzahlDossiersExport', NULL,
+        N'Dossiers exported in the period. The workbook''s "Dossiers" row. Group by Branch and Export month for its layout.', 'int', 370),
+    ('privera_neuzugaenge_register', 'privera_neuzugaenge',
+        N'Registers', N'Register', N'Registres', N'Registri',
+        'sum', 'AnzahlRegisterExport', NULL,
+        N'Registers exported in the period -- the workbook''s "Register" row.', 'int', 371),
+    ('privera_neuzugaenge_seiten', 'privera_neuzugaenge',
+        N'Pages', N'Seiten', N'Pages', N'Pagine',
+        'sum', 'AnzahlSeitenExport', NULL,
+        N'Pages exported in the period -- the workbook''s "Seiten" row.', 'int', 372)
+) AS v(Code, SourceId, Label, De, Fr, It, Agg, BaseField, Filt, Descr, Fmt, SortOrder)
+WHERE NOT EXISTS (SELECT 1 FROM dbo.ReportingMetrics m WHERE m.Code = v.Code);
+GO

--- a/sql/_migrations/NexoraDB/0135_seed_privera_posteingang_source.sql
+++ b/sql/_migrations/NexoraDB/0135_seed_privera_posteingang_source.sql
@@ -1,0 +1,94 @@
+-- 0135_seed_privera_posteingang_source.sql
+-- Privera Posteingang, from AES Sprint 54 (#329) -- the sixth and last of the
+-- monthly workbooks. Replaces
+-- R:\...\Privera\01_Posteingang\Statistik\Privera-Statistik_TP01-Posteingang-<YYYYMM>.xlsx
+-- with a source over 01_Privera_Posteingang.dbo.Reporting_P1_Dokumente.
+--
+-- WHAT THE OLD REPORT IS
+-- One pivot: rows Register, columns Niederlassung, page filter ExportDatetime,
+-- a single data field "Anzahl von Barcode". August 2026 published 10,044.
+--
+-- THE DATE COLUMN IS TEXT, AND THAT SHAPES EVERYTHING BELOW
+-- ExportDatetime is nvarchar holding 'dd.MM.yyyy HH:mm:ss'. It cannot be
+-- declared a date here. Our connection runs us_english, so asking SQL Server to
+-- read it as one gives:
+--     '01.02.2021' (1 February)  -> year 2021, MONTH 1   -- silently wrong
+--     '25.08.2026' (day > 12)    -> Conversion failed    -- the query errors
+-- Both measured against PROD, not assumed. So most months would fail outright
+-- and the survivors would be wrong -- the worst combination for a billing
+-- figure.
+--
+-- SO THE COLUMN IS EXPOSED AS A STRING
+-- Picking a month is a `contains` filter on 'Export date (text)': `.08.2026`
+-- renders as LIKE '%.08.2026%' and returns exactly the published 10,044,
+-- verified. That is the same shape as the workbook, which is one file per month
+-- with the month ticked in a filter -- so nothing is lost against what this
+-- replaces.
+--
+-- WHAT IS LOST, AND HOW TO GET IT BACK
+-- No month grain, so no monthly series or chart over time: grouping needs a
+-- real date. The fix belongs in the source database, not here. Reporting_P1_Dokumente
+-- is a VIEW, so it is one added column, no table change and no back-fill:
+--     TRY_CONVERT(datetime, ExportDatetime, 104) AS ExportDatetime_dt
+-- (104 is day-first German; TRY_CONVERT yields NULL rather than failing on a
+-- malformed row). That expression returns exactly 10,044 for August too. Once
+-- the column exists, add it to ColumnsJSON as a grainable date and this source
+-- gains the grain with no other change. Tracked on #329.
+--
+-- WHY NOT TEACH THE REPORTING LAYER TO PARSE TEXT DATES
+-- It was considered. It would mean wrapping every reference to the column --
+-- select, group by, where, order by -- in a conversion, in code every source
+-- shares, to accommodate one column in one view; and it would defeat any index
+-- on 858k rows. A view column is cheaper, correct at the source, and helps
+-- every other tool reading that view.
+--
+-- PROPERTY AND RECIPIENT COLUMNS ARE NOT EXPOSED
+-- Same call as 0132: EigentuemerNr, LiegenschaftsNr, MietverhaeltnisNr and
+-- Empfaenger identify a property, its owner, a tenancy and a named recipient.
+-- Counting documents needs none of them.
+--
+-- Permission follows reporting.source.<code>.use (0088). Idempotent.
+
+INSERT INTO dbo.Permission (Code, Description)
+SELECT N'reporting.source.privera_posteingang.use', N'Use the Privera Posteingang source'
+WHERE NOT EXISTS (SELECT 1 FROM dbo.Permission WHERE Code = N'reporting.source.privera_posteingang.use');
+GO
+
+IF NOT EXISTS (SELECT 1 FROM dbo.ReportingSources WHERE Code = 'privera_posteingang')
+INSERT INTO dbo.ReportingSources
+    (Code, Kind, Label, Permission, Engine, Provider, BaseObject, ColumnsJSON, Enabled, SortOrder)
+VALUES (
+    'privera_posteingang', 'curated', N'Privera — Posteingang',
+    'reporting.source.privera_posteingang.use', 'statistics', 'table',
+    '01_Privera_Posteingang.dbo.Reporting_P1_Dokumente',
+    N'[{"field":"ExportDatetime","label":"Export date (text)","type":"string","filterable":true,"sortable":true},
+       {"field":"Register","label":"Register","type":"string","filterable":true,"sortable":true},
+       {"field":"Niederlassung","label":"Branch","type":"string","filterable":true,"sortable":true},
+       {"field":"Dokumenttyp","label":"Document type","type":"string","filterable":true,"sortable":true},
+       {"field":"DossierTyp","label":"Dossier type","type":"string","filterable":true,"sortable":true},
+       {"field":"Abteilung","label":"Department","type":"string","filterable":true,"sortable":true},
+       {"field":"Art","label":"Kind","type":"string","filterable":true,"sortable":true},
+       {"field":"Nachsendung","label":"Forwarding","type":"string","filterable":true,"sortable":true},
+       {"field":"Einschreiben","label":"Registered post","type":"string","filterable":true,"sortable":true},
+       {"field":"Vertraulichkeit","label":"Confidentiality","type":"string","filterable":true,"sortable":true},
+       {"field":"ScanSource","label":"Scan source","type":"string","filterable":true,"sortable":true},
+       {"field":"ScanUser","label":"Scan user","type":"string","filterable":true,"sortable":true},
+       {"field":"ValUser","label":"Validation user","type":"string","filterable":true,"sortable":true},
+       {"field":"AnzahlImagesScanned","label":"Images scanned","type":"number","filterable":true,"sortable":true},
+       {"field":"AnzahlImagesProcessed","label":"Images processed","type":"number","filterable":true,"sortable":true},
+       {"field":"DokumentRescanAm","label":"Rescanned at","type":"date","filterable":true,"sortable":true,"grainable":true},
+       {"field":"DokumentGeloeschtAm","label":"Deleted at","type":"date","filterable":true,"sortable":true,"grainable":true}]',
+    1, 380);
+GO
+
+INSERT INTO dbo.ReportingMetrics
+    (Code, SourceId, Label, GermanLabel, FrenchLabel, ItalianLabel, Aggregation, BaseField, FilterJson, Description, Format, SortOrder)
+SELECT v.Code, v.SourceId, v.Label, v.De, v.Fr, v.It, v.Agg, v.BaseField, v.Filt, v.Descr, v.Fmt, v.SortOrder
+FROM (VALUES
+    ('privera_posteingang_documents', 'privera_posteingang',
+        N'Documents', N'Dokumente', N'Documents', N'Documenti',
+        'count', NULL, NULL,
+        N'The billed figure, the workbook''s "Anzahl von Barcode". Pick a month with a contains filter on Export date (text) -- e.g. .08.2026 -- because that column is text, not a date, so it cannot be grouped by month. Group by Register and Branch for the workbook''s layout.', 'int', 380)
+) AS v(Code, SourceId, Label, De, Fr, It, Agg, BaseField, Filt, Descr, Fmt, SortOrder)
+WHERE NOT EXISTS (SELECT 1 FROM dbo.ReportingMetrics m WHERE m.Code = v.Code);
+GO

--- a/tests/unit/test_billing_sources.py
+++ b/tests/unit/test_billing_sources.py
@@ -33,6 +33,7 @@ MIGRATIONS = REPO / "sql" / "_migrations" / "NexoraDB"
 COMPASS = MIGRATIONS / "0131_seed_compass_invoice_source.sql"
 PRIVERA = MIGRATIONS / "0132_seed_privera_invoice_source.sql"
 NACHSEND = MIGRATIONS / "0133_seed_privera_nachsendungen_source.sql"
+NEUZUG = MIGRATIONS / "0134_seed_privera_neuzugaenge_source.sql"
 EM = MIGRATIONS / "0130_seed_em_invoice_source.sql"
 
 ALL_BILLING = {
@@ -40,6 +41,7 @@ ALL_BILLING = {
     "compass_invoice": COMPASS,
     "privera_invoice": PRIVERA,
     "privera_nachsendungen": NACHSEND,
+    "privera_neuzugaenge": NEUZUG,
 }
 
 # Columns that exist in these tables and must never reach a catalogue. Billing
@@ -251,3 +253,47 @@ def test_ohne_tec_excludes_the_forwarding_type_not_the_branch():
     )
     assert cond[0]["op"] == "ne"
     assert cond[0]["value"] == "Rechnungen Privera TEC"
+
+
+# --------------------------------------------------------------------------
+# Privera Neuzugänge -- a view that is already aggregated per month.
+# --------------------------------------------------------------------------
+
+
+def test_neuzugaenge_registers_the_three_published_rows():
+    """The workbook's pivot has three data rows: Dossiers, Register, Seiten."""
+    sql = _sql(NEUZUG)
+    for code in (
+        "privera_neuzugaenge_dossiers",
+        "privera_neuzugaenge_register",
+        "privera_neuzugaenge_seiten",
+    ):
+        assert f"'{code}'" in sql, f"{code} is missing"
+        assert _filter_of(NEUZUG, code) is None, f"{code} should not be filtered"
+
+
+def test_neuzugaenge_does_not_reproduce_the_summed_year():
+    """The workbook's pivot carries a fourth data field, "Summe von
+    JahrExport" -- somebody dropping the year into the values by accident. It
+    totals 32,416 for 2026 and means nothing. Copying a source faithfully means
+    copying what it *meant*, not every field that ended up in it."""
+    sql = _sql(NEUZUG)
+    assert "'sum', 'JahrExport'" not in sql, "the year is being summed as a measure"
+    for code in (
+        "privera_neuzugaenge_dossiers",
+        "privera_neuzugaenge_register",
+        "privera_neuzugaenge_seiten",
+    ):
+        block = _measure_block(NEUZUG, code)
+        assert "JahrExport" not in block, f"{code} aggregates the year"
+
+
+def test_neuzugaenge_treats_year_and_month_as_dimensions_not_a_date():
+    """The view has no date column -- only a year and a month number -- because
+    it is already aggregated per month. Declaring either as a grainable date
+    would ask SQL Server to read an integer as one."""
+    cols = _columns(NEUZUG)
+    for f in ("JahrExport", "MonatExportNr"):
+        assert f in cols, f"{f} is not exposed"
+        assert cols[f]["type"] == "number", f"{f} must be a number, not a date"
+        assert not cols[f].get("grainable"), f"{f} must not claim a date grain"

--- a/tests/unit/test_billing_sources.py
+++ b/tests/unit/test_billing_sources.py
@@ -34,6 +34,7 @@ COMPASS = MIGRATIONS / "0131_seed_compass_invoice_source.sql"
 PRIVERA = MIGRATIONS / "0132_seed_privera_invoice_source.sql"
 NACHSEND = MIGRATIONS / "0133_seed_privera_nachsendungen_source.sql"
 NEUZUG = MIGRATIONS / "0134_seed_privera_neuzugaenge_source.sql"
+POSTEIN = MIGRATIONS / "0135_seed_privera_posteingang_source.sql"
 EM = MIGRATIONS / "0130_seed_em_invoice_source.sql"
 
 ALL_BILLING = {
@@ -42,6 +43,7 @@ ALL_BILLING = {
     "privera_invoice": PRIVERA,
     "privera_nachsendungen": NACHSEND,
     "privera_neuzugaenge": NEUZUG,
+    "privera_posteingang": POSTEIN,
 }
 
 # Columns that exist in these tables and must never reach a catalogue. Billing
@@ -63,6 +65,8 @@ NEVER_EXPOSED = (
     "InvoiceNR",
     "LiegenschaftsNr",
     "EigentuemerNr",
+    "MietverhaeltnisNr",
+    "Empfaenger",
 )
 
 
@@ -297,3 +301,46 @@ def test_neuzugaenge_treats_year_and_month_as_dimensions_not_a_date():
         assert f in cols, f"{f} is not exposed"
         assert cols[f]["type"] == "number", f"{f} must be a number, not a date"
         assert not cols[f].get("grainable"), f"{f} must not claim a date grain"
+
+
+# --------------------------------------------------------------------------
+# Privera Posteingang -- the one whose date column is text.
+# --------------------------------------------------------------------------
+
+
+def test_posteingang_does_not_claim_its_text_column_is_a_date():
+    """The load-bearing one. ExportDatetime is nvarchar holding 'dd.MM.yyyy',
+    and the connection runs us_english, so asking SQL Server to read it as a
+    date gives 1 February back as 2 January and raises outright on any day past
+    the 12th -- both measured against PROD. Declaring it a date here would ship
+    a billing report that fails most months and is wrong the rest of the time."""
+    cols = _columns(POSTEIN)
+    assert "ExportDatetime" in cols, "the export column is not exposed at all"
+    spec = cols["ExportDatetime"]
+    assert spec["type"] == "string", (
+        "ExportDatetime is nvarchar 'dd.MM.yyyy HH:mm:ss' -- typing it as a date "
+        "makes SQL Server parse it under us_english: silently wrong, then failing"
+    )
+    assert not spec.get("grainable"), "a text column cannot carry a month grain"
+
+
+def test_posteingang_counts_documents_unfiltered():
+    """The workbook's single data field, "Anzahl von Barcode". The month is a
+    filter the user applies, not part of the measure."""
+    assert "'privera_posteingang_documents'" in _sql(POSTEIN)
+    assert _filter_of(POSTEIN, "privera_posteingang_documents") is None
+
+
+def test_posteingang_keeps_the_workbooks_two_dimensions():
+    """Rows Register, columns Niederlassung -- without both, the grid the
+    customer is used to seeing cannot be rebuilt."""
+    cols = _columns(POSTEIN)
+    for f in ("Register", "Niederlassung"):
+        assert f in cols, f"{f} is missing, so the workbook layout is unreachable"
+
+
+def test_posteingang_tells_the_user_how_to_pick_a_month():
+    """A text date is surprising enough that the measure has to say so; there is
+    nowhere else the reader would find out."""
+    block = _measure_block(POSTEIN, "privera_posteingang_documents")
+    assert "contains" in block, "the description must explain the contains filter"


### PR DESCRIPTION
Fifth of the six from #329.

**I had this down as blocked, and that was wrong.** The view is broken on **INT**, where it binds to a stray `SYDOC_Statistik1.dbo.PriveraInitialUndNeuzugaenge`. On **PROD it works fine** — 240 rows of current data, which is why the workbook has been refreshing all along. Holding the whole source back over a broken *dev* copy was the wrong trade.

So it is registered, with the INT breakage written into the migration header so the first person to test there is not left guessing.

### Verified month by month against the published 2026 workbook

| month | Dossiers | Registers | Pages |
|---|---|---|---|
| January | exact | exact | exact |
| February | exact | exact | exact |
| April | exact | exact | exact |
| June | exact | exact | exact |
| July | exact | exact | exact |
| August | exact | exact | exact |
| September | 30 → 778 | 120 → 3112 | 2752 → 31394 |

**18 of 21 figures exact.** Every closed month agrees on every measure. September differs because that workbook was refreshed on 2026-09-01, when the month was one day old — so the difference is ten days of real data, not a discrepancy.

### Shape

The view is already aggregated: one row per year / month number / Niederlassung carrying three counters. So all three measures are plain sums, and year and month stay **numeric dimensions** rather than a grainable date — there is no date column, and declaring an integer as one would ask SQL Server to parse it as a date.

### Not reproduced, on purpose

The workbook's pivot carries a fourth data field, **"Summe von JahrExport"** — the year dragged into the values by accident. It totals 32,416 for 2026 and means nothing. Copying a report faithfully means copying what it *meant*, not every field that ended up in it. A test checks the year is never aggregated here.

3 new guards, 18 in the file, 1844 unit tests green. Migration applied to INT.

That leaves **Posteingang** as the only one of the six still blocked, and that one genuinely is — its `ExportDatetime` is text, so it needs a real date column or a converting view on the source database.