### PR TITLE
feat(permissions): grant the billing sources to Global Admin (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,16 @@ uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   old copy still writes — see `scripts/generali-import/README.md`.
 
 ### Fixed
+- **The billing sources were invisible to Global Admin** (#329) — migration
+  `0136` grants the six sources from `0130`–`0135` to that profile. They
+  deployed correctly, but `0130`–`0135` create each permission and grant it to
+  nobody; Enterprise Admin still picked them up because it holds *every*
+  permission (136 of 136 on PROD), while Global Admin carries a hand-picked
+  subset and had none of them — nor xpert_stats, bucherer_easytax, frigemo,
+  bps_projects or most generali sources. Granted as a migration rather than in
+  the admin UI, because the dormant grant on #332 is what a hand-made one looks
+  like six months later. No customer-facing profile is touched — none of them
+  holds `reporting.view` at all.
 - **env-sync's ACTION NEEDED no longer cries wolf** (#313) — the headline
   alarm fired on 11 keys absent from `env/PROD.env` on the server, and all 11
   were false positives: each has a code default identical to the value

--- a/sql/_migrations/NexoraDB/0136_grant_billing_sources_to_global_admin.sql
+++ b/sql/_migrations/NexoraDB/0136_grant_billing_sources_to_global_admin.sql
@@ -1,0 +1,47 @@
+-- 0136_grant_billing_sources_to_global_admin.sql
+-- Grant the six billing sources from 0130-0135 to the 'Global Admin' profile
+-- (#329).
+--
+-- WHY THIS IS NEEDED AT ALL
+-- 0130-0135 create each source's permission but grant it to nobody. Enterprise
+-- Admin still ends up holding them because that profile holds *every*
+-- permission -- 136 of 136 on PROD -- so it picks up anything new for free.
+-- Global Admin does not: it carries a hand-picked subset and was missing all
+-- six, along with xpert_stats, bucherer_easytax, frigemo, bps_projects and most
+-- of the generali sources. So the sources deployed correctly and were simply
+-- invisible to the one person who needed to check them.
+--
+-- WHY GLOBAL ADMIN AND NOBODY ELSE
+-- It is internal SYDOC staff at rank 90, one user, and it already holds
+-- reporting.view plus reporting.sql.run -- someone with the SQL sandbox can
+-- already read these tables directly, so this grants no reach that profile did
+-- not effectively have. It does not touch any customer-facing profile: those
+-- hold no reporting.view at all, and the row-scoping caveat on #332 still
+-- applies to anyone who later wants a customer to see their own figures.
+--
+-- Deliberately a migration and not a click in the admin UI. The dormant
+-- MediaMarkt grant on #332 exists precisely because somebody did it by hand:
+-- INT and PROD disagree, and there is no record of who or why.
+--
+-- Idempotent, and self-limiting -- it inserts nothing if either the profile or
+-- the permission is absent, so a fresh INT without the profile is a no-op
+-- rather than an error.
+
+INSERT INTO dbo.AccessProfilePermission (AccessID, PermissionID)
+SELECT ap.AccessID, p.PermissionID
+FROM dbo.AccessProfile ap
+CROSS JOIN dbo.Permission p
+WHERE ap.Name = N'Global Admin'
+  AND p.Code IN (
+      N'reporting.source.em_invoice.use',
+      N'reporting.source.compass_invoice.use',
+      N'reporting.source.privera_invoice.use',
+      N'reporting.source.privera_nachsendungen.use',
+      N'reporting.source.privera_neuzugaenge.use',
+      N'reporting.source.privera_posteingang.use'
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM dbo.AccessProfilePermission x
+      WHERE x.AccessID = ap.AccessID AND x.PermissionID = p.PermissionID
+  );
+GO


### PR DESCRIPTION
The six sources from `0130`–`0135` deployed correctly and are **invisible to the person who needs to check them**.

`0130`–`0135` create each source's permission and grant it to nobody. Enterprise Admin still ends up holding them because that profile holds **every** permission — 136 of 136 on PROD — so it picks up anything new for free. Global Admin does not: it carries a hand-picked subset, and was missing all six.

This is not new breakage. Global Admin is also missing `xpert_stats`, `bucherer_easytax`, `frigemo`, `bps_projects` and most of the generali sources — the same gap for every source added this way.

### Scope

Global Admin only: internal staff, rank 90, one user. It already holds `reporting.view` and `reporting.sql.run`, so anyone in it can read these tables directly through the SQL sandbox — this grants no reach the profile did not effectively have.

**No customer-facing profile is touched.** None of them holds `reporting.view` at all, and the row-scoping caveat on #332 still governs anyone who later wants a customer to see their own figures.

### Why a migration and not the admin UI

Because the dormant MediaMarkt grant on #332 is what a hand-made one looks like months later: INT and PROD disagreeing, with no record of who did it or why. This way both environments say the same thing and the reasoning is in the file.

Idempotent and self-limiting — it inserts nothing if either the profile or a permission is absent, so a fresh environment is a no-op rather than an error. Applied to INT: 6 rows.